### PR TITLE
feat(solara/aoi): restore AoiView from a pre-populated value at mount

### DIFF
--- a/pysepal/solara/components/aoi/admin.py
+++ b/pysepal/solara/components/aoi/admin.py
@@ -184,6 +184,37 @@ def fetch_admin_items(
     return item_list
 
 
+def admin_parent_chain(method: str, code: Optional[str]) -> Dict[int, str]:
+    """Map a final GAUL admin code to its full ``{level: code}`` parent chain.
+
+    Restoring an ADMIN1/ADMIN2 cascade needs the parent codes (to load the
+    child dropdown lists), but only the final code is usually persisted. Look
+    the parents up in pygaul's GAUL 2024 parquet. Returns ``{}`` when the code
+    is falsy/unknown or the lookup fails, so callers can fall back to
+    restoring the method only.
+
+    Args:
+        method: The admin method ("ADMIN0", "ADMIN1", or "ADMIN2")
+        code: The final admin code of the persisted selection
+
+    Returns:
+        ``{level: code}`` for every level from 0 down to the method's level,
+        or ``{}`` when the chain cannot be resolved.
+    """
+    if not code:
+        return {}
+    try:
+        level = int(method[-1])
+        df = pygaul._df()
+        rows = df[df[f"gaul{level}_code"].astype(str) == str(code)]
+        if rows.empty:
+            return {}
+        row = rows.iloc[0]
+        return {lvl: str(row[f"gaul{lvl}_code"]) for lvl in range(level + 1)}
+    except Exception:
+        return {}
+
+
 async def process_admin(
     method: str,
     admin_code: str,

--- a/pysepal/solara/components/aoi/admin.py
+++ b/pysepal/solara/components/aoi/admin.py
@@ -4,6 +4,7 @@ Functions for selecting and processing administrative boundaries using
 FAO GAUL 2024 data (both WFS for non-GEE and sat-io asset for GEE).
 """
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -276,10 +277,16 @@ async def process_admin(
             # Use pygaul.Items to get the feature collection (handles all the EE logic)
             feature_collection = pygaul.Items(admin=admin_code)
 
-            # Get properties for naming (async call)
+            # Get properties for naming. Use the blocking API in a worker
+            # thread: eeclient's pooled httpx connection binds to the first
+            # loop that drives it, so awaiting get_info_async here would bind
+            # it to the caller's loop and later private-loop calls (e.g.
+            # add_ee_layer -> get_map_id) would raise "bound to a different
+            # event loop".
             feature = feature_collection.first()
-            properties = await interface.get_info_async(
-                feature.toDictionary(feature.propertyNames())
+            properties = await asyncio.to_thread(
+                interface.get_info,
+                feature.toDictionary(feature.propertyNames()),
             )
 
             # Build name from ISO code and admin names

--- a/pysepal/solara/components/aoi/aoi_result.py
+++ b/pysepal/solara/components/aoi/aoi_result.py
@@ -4,7 +4,7 @@ Common dataclass used across all AOI selection methods.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import geopandas as gpd
 from deprecated.sphinx import versionadded
@@ -28,6 +28,10 @@ class AoiResult:
         feature_collection: ee.ComputedObject for GEE workflows (FeatureCollection, Image, etc.; None otherwise)
         admin: Admin code for admin methods (None for other methods)
         gee: Whether this result was created with GEE binding
+        asset: For ASSET selections, the picker inputs
+            ``{asset_id, type, column, value}`` (None for other methods).
+            Persisting this dict lets apps rebuild an equivalent AoiResult and
+            restore the asset picker on load.
 
     Example:
         ```python
@@ -47,6 +51,7 @@ class AoiResult:
     feature_collection: Optional[Any] = field(default=None, repr=False)  # ee.ComputedObject
     admin: Optional[str] = None
     gee: bool = False
+    asset: Optional[Dict[str, Any]] = field(default=None, repr=False)
 
     async def get_gdf_async(self) -> Optional[gpd.GeoDataFrame]:
         """Fetch the GeoDataFrame asynchronously.

--- a/pysepal/solara/components/aoi/aoi_view.py
+++ b/pysepal/solara/components/aoi/aoi_view.py
@@ -175,6 +175,15 @@ def AoiView(
             The clear callback preserves the currently selected method so the
             user can retry without reselecting it.
 
+    Restore-on-mount:
+        When ``value`` already holds an ``AoiResult`` at mount (e.g. rebuilt
+        from a persisted project), the picker restores itself: the method
+        select, admin cascade, draw name/control and asset field are seeded
+        from the result, and the selection is auto-confirmed (map layer drawn,
+        success feedback) without reprocessing. To restore a different AOI
+        later, set ``value`` and remount (e.g. key the component on a
+        load signal).
+
     Example:
         ```python
         @solara.component
@@ -222,6 +231,25 @@ def AoiView(
     points_data = solara.use_reactive(None)
     asset_data = solara.use_reactive(None)
     asset_loading = solara.use_reactive(False)
+
+    # The method we restored on mount. on_method_change skips its clear while
+    # the selected method equals this, so restore (and reacton's double
+    # effect-run) doesn't wipe the loaded AOI. Cleared on the first genuine
+    # user change.
+    restored_method = solara.use_ref(None)
+
+    # When True, the next process_aoi run is an auto-select of the
+    # just-restored AOI: it reuses the already-loaded AoiResult instead of
+    # re-running the live picker, so it can't race the still-settling admin
+    # cascade / asset validation. It renders the map layer + shows the
+    # confirmation, exactly as ending a manual "Select AOI" press would.
+    restore_pending = solara.use_ref(False)
+
+    # The AoiResult captured synchronously at restore time. The auto-select
+    # uses this rather than the shared value reactive, which can be transiently
+    # None when a previous AoiView instance's unmount cleanup fires during a
+    # load-triggered remount. process_aoi re-publishes it via reactive_value.set.
+    restore_result = solara.use_ref(None)
 
     # Notification system (replaces embedded alert). When no
     # NotificationProvider is mounted, `notifications` is a NoopNotifier
@@ -298,6 +326,40 @@ def AoiView(
 
     solara.use_effect(_register_clear, [])
 
+    def _seed_draw_control(gdf):
+        # Best-effort: re-populate the editable DrawControl from a restored gdf
+        # so a restored DRAW AOI stays editable. The geometry is rendered by the
+        # auto-select regardless, so a failure here is cosmetic.
+        if not (map_ and aoi_dc) or gdf is None:
+            return
+        try:
+            import json
+
+            features = json.loads(gdf.to_crs(epsg=4326).to_json())["features"]
+            aoi_dc.data = features
+            if aoi_dc not in map_.controls:
+                map_.add_control(aoi_dc)
+        except Exception:
+            pass
+
+    def _apply_restore():
+        result = reactive_value.value  # the loaded AoiResult (set before mount)
+        if result is None or not getattr(result, "method", None):
+            return
+        method = result.method
+        restored_method.current = method  # set BEFORE selected_method so the guard sees it
+        restore_result.current = result  # capture now; the shared reactive may churn on remount
+        restore_pending.current = True  # auto-select this restored AOI (see _autoselect_restored)
+        selected_method.set(method)
+        if method in ("ADMIN0", "ADMIN1", "ADMIN2"):
+            admin_code.set(result.admin)
+        elif method == "DRAW":
+            draw_name.set(result.name or "")
+            _seed_draw_control(getattr(result, "gdf", None))
+        # ASSET: AssetSelectComponent seeds from initial=result.asset.
+
+    solara.use_effect(_apply_restore, [])
+
     # Track the current task in the notification system
     task_tracker_ref = solara.use_ref(None)
 
@@ -314,7 +376,18 @@ def AoiView(
         try:
             tracker.step("Validating input...")
 
-            if method in ["ADMIN0", "ADMIN1", "ADMIN2"]:
+            # Auto-select on restore: reuse the already-loaded AoiResult
+            # instead of re-running the live picker, which would race the
+            # still-settling admin cascade / asset validation. Just render it
+            # on the map + confirm below.
+            if restore_pending.current:
+                restore_pending.current = False
+                result = restore_result.current
+                if result is None:
+                    raise ValueError("No AOI to restore")
+                method = result.method
+
+            elif method in ["ADMIN0", "ADMIN1", "ADMIN2"]:
                 if not admin_code.value:
                     raise ValueError(f"Please select a {method} region")
 
@@ -463,9 +536,24 @@ def AoiView(
         fallback_level.set("info")
         task()
 
+    def _autoselect_restored():
+        # Mirror a "Select AOI" press for the just-restored AOI so the panel
+        # lands in the confirmed state (map layer drawn + success feedback)
+        # rather than a filled-but-unsubmitted form. Runs once per (re)mount;
+        # _apply_restore set restore_pending when it found a loaded AoiResult.
+        if restore_pending.current and reactive_value.value is not None:
+            start_process()
+
+    solara.use_effect(_autoselect_restored, [])
+
     # Handle method changes
     def on_method_change():
         if selected_method.value:
+            # Skip the clear for the restore-driven method (survives reacton's
+            # double effect-run); the first genuine user change clears it.
+            if selected_method.value == restored_method.current:
+                return
+            restored_method.current = None
             _clear_current_aoi(active_method=selected_method.value)
 
     solara.use_effect(on_method_change, [selected_method.value])
@@ -505,6 +593,7 @@ def AoiView(
                 method=selected_method.value,
                 gee=gee,
                 value=admin_code,
+                initial=admin_code.value,
             )
 
         elif selected_method.value == "SHAPE":
@@ -539,6 +628,13 @@ def AoiView(
                 gee_interface=session_gee_interface,
                 value=asset_data,
                 loading=asset_loading,
+                # Seed the restored asset selection; cleared once the user
+                # genuinely changes method (restored_method guard).
+                initial=(
+                    getattr(restore_result.current, "asset", None)
+                    if restored_method.current == "ASSET"
+                    else None
+                ),
             )
 
         # Action buttons

--- a/pysepal/solara/components/aoi/aoi_view.py
+++ b/pysepal/solara/components/aoi/aoi_view.py
@@ -18,6 +18,7 @@ Usage:
             print(f"Selected: {aoi.value.name}")
 """
 
+import asyncio
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import reacton.ipyvuetify as rv
@@ -290,11 +291,22 @@ def AoiView(
         reset_method: bool = False,
         active_method: Optional[str] = None,
         reset_loading: bool = False,
+        clear_value: bool = True,
     ):
+        """Drop the current selection and everything it put on the map.
+
+        Args:
+            clear_value: Whether to also reset ``value`` to None. ``value`` may
+                be a reactive owned by the host app, so only user-driven
+                clears (method change, clear button) may null it. Teardown
+                paths pass False: unmounting the picker must not erase a
+                selection the app is still holding.
+        """
         if reset_loading:
             reactive_loading.set(False)
 
-        reactive_value.set(None)
+        if clear_value:
+            reactive_value.set(None)
         admin_code.set(None)
         draw_name.set("")
         shape_data.set(None)
@@ -451,7 +463,15 @@ def AoiView(
 
                 # Add new AOI layer
                 if gee and result.feature_collection:
-                    await map_.add_ee_layer_async(
+                    # eeclient's pooled HTTP/2 connection binds to the loop
+                    # that first uses it. Any sync-API GEE traffic (e.g. an
+                    # app's project load) binds it to GEEInterface's private
+                    # loop, after which awaiting the *_async map path here —
+                    # on Solara's kernel loop — raises "bound to a different
+                    # event loop". The blocking API in a worker thread is
+                    # loop-safe: it dispatches to the interface's own loop.
+                    await asyncio.to_thread(
+                        map_.add_ee_layer,
                         result.feature_collection,
                         map_style or {},
                         "aoi",
@@ -565,7 +585,13 @@ def AoiView(
             # _CancelledErrorInOurTask which propagates up. The task will be
             # garbage collected when the component unmounts.
 
-            _clear_current_aoi(active_method="", reset_loading=True)
+            # Release only what this picker owns (map layers, draw control,
+            # loading flag). `value` belongs to the caller — use_reactive passes
+            # a host-owned reactive straight through — and unmounting the widget
+            # is not the user dropping their AOI. Nulling it here wiped app
+            # state on a panel collapse / conditional render / keyed remount,
+            # which for apps that persist the AOI meant saving an empty one.
+            _clear_current_aoi(active_method="", reset_loading=True, clear_value=False)
 
             # Note: We intentionally do NOT reset map center/zoom on unmount
             # to avoid surprising side effects for host apps that own the map state

--- a/pysepal/solara/components/aoi/asset.py
+++ b/pysepal/solara/components/aoi/asset.py
@@ -71,4 +71,6 @@ async def process_asset(
         feature_collection=ee_object,
         admin=None,
         gee=True,
+        # Round-trip the picker inputs so apps can persist and restore them.
+        asset={"asset_id": asset_id, "type": asset_type, "column": column, "value": value},
     )

--- a/pysepal/solara/components/inputs/admin_selector.py
+++ b/pysepal/solara/components/inputs/admin_selector.py
@@ -16,6 +16,7 @@ def AdminLevelSelector(
     gee: bool = True,
     value: Union[str, solara.Reactive[Optional[str]]] = None,
     on_value: Optional[Callable[[Optional[str]], None]] = None,
+    initial: Optional[str] = None,
 ):
     """Self-contained administrative level selector with cascading dropdowns.
 
@@ -28,6 +29,10 @@ def AdminLevelSelector(
         gee: Whether to use Earth Engine (GAUL) or FAO WFS (local)
         value: The final selected admin code (output only)
         on_value: Callback when the final admin code changes
+        initial: Restore seed — the final admin code of a previously persisted
+            selection. Snapshotted at mount; the full cascade (parent levels
+            included) is seeded from it exactly once. Remount the component to
+            restore a different selection.
 
     Returns:
         None. The final admin code is passed through value/on_value.
@@ -66,6 +71,37 @@ def AdminLevelSelector(
 
     target_level = {"ADMIN0": 0, "ADMIN1": 1, "ADMIN2": 2}.get(method, 0)
 
+    # Snapshot the restore seed at first mount. Callers (AoiView) may bind
+    # `initial` live to the same reactive this component drives via `value`, and
+    # update_output resets that reactive to None on mount before the async
+    # cascade seeds — so reading `initial` live would wipe the restore chain to
+    # {} and leave the dropdowns empty. Freezing it (deps=[]) keeps the chain
+    # stable; a genuine re-restore remounts the component.
+    initial_seed = solara.use_memo(lambda: initial, [])
+
+    def _compute_chain():
+        # Local import breaks the cycle: aoi/__init__ -> aoi_view -> this module.
+        from pysepal.solara.components.aoi.admin import admin_parent_chain
+
+        return admin_parent_chain(method, initial_seed)
+
+    _chain = solara.use_memo(_compute_chain, [method, initial_seed])
+    # Levels auto-seeded from the restore chain. A per-level one-shot guard (not a
+    # shared flag) so the async loaders can seed in any order, exactly once each,
+    # and a later genuine user change of a parent still resets its children.
+    _seeded = solara.use_ref(set())
+
+    # The (parent, target_level) each child loader last processed. Under reacton's
+    # double effect-run the loaders fire twice per dependency change; the second,
+    # redundant run for an UNCHANGED parent would otherwise take the else-branch
+    # and wipe the value the first run just restored from the chain (leaving the
+    # dropdowns empty on restore). Short-circuiting on an unchanged parent keeps
+    # the seed and skips a duplicate fetch; a genuine parent change still flows
+    # through to reseed or clear stale children.
+    _UNSET = solara.use_memo(lambda: object(), [])
+    _level1_parent = solara.use_ref(_UNSET)
+    _level2_parent = solara.use_ref(_UNSET)
+
     async def _load_level_0():
         # Local import breaks the cycle: aoi/__init__ -> aoi_view -> this module.
         from pysepal.solara.components.aoi.admin import fetch_admin_items
@@ -74,6 +110,9 @@ def AdminLevelSelector(
         try:
             items = fetch_admin_items(level=0, parent_code="")
             items_0.set(items)
+            if _chain.get(0) and 0 not in _seeded.current:
+                _seeded.current = _seeded.current | {0}
+                level_0.set(_chain[0])
         finally:
             loading_0.set(False)
 
@@ -82,16 +121,26 @@ def AdminLevelSelector(
     async def _load_level_1():
         from pysepal.solara.components.aoi.admin import fetch_admin_items
 
+        key = (level_0.value, target_level)
+        if _level1_parent.current == key:
+            return
+        _level1_parent.current = key
+
         if level_0.value and target_level >= 1:
             loading_1.set(True)
             try:
                 items = fetch_admin_items(level=1, parent_code=level_0.value)
                 items_1.set(items)
+                if _chain.get(1) and 1 not in _seeded.current:
+                    _seeded.current = _seeded.current | {1}
+                    level_1.set(_chain[1])
+                else:
+                    level_1.set(None)
             finally:
                 loading_1.set(False)
         else:
             items_1.set([])
-        level_1.set(None)
+            level_1.set(None)
         level_2.set(None)
         items_2.set([])
 
@@ -104,16 +153,26 @@ def AdminLevelSelector(
     async def _load_level_2():
         from pysepal.solara.components.aoi.admin import fetch_admin_items
 
+        key = (level_1.value, target_level)
+        if _level2_parent.current == key:
+            return
+        _level2_parent.current = key
+
         if level_1.value and target_level >= 2:
             loading_2.set(True)
             try:
                 items = fetch_admin_items(level=2, parent_code=level_1.value)
                 items_2.set(items)
+                if _chain.get(2) and 2 not in _seeded.current:
+                    _seeded.current = _seeded.current | {2}
+                    level_2.set(_chain[2])
+                else:
+                    level_2.set(None)
             finally:
                 loading_2.set(False)
         else:
             items_2.set([])
-        level_2.set(None)
+            level_2.set(None)
 
     solara.lab.use_task(
         _load_level_2,

--- a/pysepal/solara/components/inputs/asset_select.py
+++ b/pysepal/solara/components/inputs/asset_select.py
@@ -78,9 +78,7 @@ def AssetSelectComponent(
     loading_values = solara.use_reactive(False)
     validation_msg = solara.use_reactive("")
 
-    _restoring_filter = solara.use_ref(
-        bool(initial and initial.get("column") not in (None, "ALL"))
-    )
+    _restoring_filter = solara.use_ref(bool(initial and initial.get("column") not in (None, "ALL")))
 
     def _apply_initial():
         if initial and initial.get("asset_id"):

--- a/pysepal/solara/components/inputs/asset_select.py
+++ b/pysepal/solara/components/inputs/asset_select.py
@@ -39,6 +39,7 @@ def AssetSelectComponent(
     loading: Union[bool, solara.Reactive[bool]] = False,
     on_loading: Optional[Callable[[bool], None]] = None,
     gee_interface=None,
+    initial: Optional[Dict] = None,
 ):
     """Selector component for GEE assets.
 
@@ -53,6 +54,10 @@ def AssetSelectComponent(
         loading: Whether the component is busy (loading assets, validating, etc.).
         on_loading: Callback when loading state changes.
         gee_interface: Optional GEEInterface instance. Falls back to session default.
+        initial: Restore seed — a previously persisted selection dict
+            ``{asset_id, type, column, value}``. Applied once at mount: the
+            asset id is validated and its columns loaded as if the user had
+            picked it, then column/value are seeded when the columns arrive.
     """
     reactive_value = solara.use_reactive(value, on_value)
     reactive_loading = solara.use_reactive(loading, on_loading)
@@ -72,6 +77,25 @@ def AssetSelectComponent(
     loading_columns = solara.use_reactive(False)
     loading_values = solara.use_reactive(False)
     validation_msg = solara.use_reactive("")
+
+    _restoring_filter = solara.use_ref(
+        bool(initial and initial.get("column") not in (None, "ALL"))
+    )
+
+    def _apply_initial():
+        if initial and initial.get("asset_id"):
+            asset_id.set(initial["asset_id"])  # triggers on_asset_change -> validate + load columns
+
+    solara.use_effect(_apply_initial, [])
+
+    def _seed_filter():
+        if _restoring_filter.current and column_items.value and initial:
+            selected_column.set(initial.get("column"))
+            if initial.get("value") is not None:
+                selected_value.set(initial.get("value"))
+            _restoring_filter.current = False
+
+    solara.use_effect(_seed_filter, [column_items.value])
 
     def _sync_loading():
         reactive_loading.set(loading_assets.value or loading_columns.value or loading_values.value)

--- a/tests/test_solara/test_admin_parent_chain.py
+++ b/tests/test_solara/test_admin_parent_chain.py
@@ -1,0 +1,53 @@
+"""Tests for admin_parent_chain (GAUL parent-chain lookup for cascade restore)."""
+
+import pandas as pd
+import pygaul
+import pytest
+
+from pysepal.solara.components.aoi import admin as admin_mod
+
+
+@pytest.fixture
+def fake_gaul(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "gaul0_code": [197, 206, 101],
+            "gaul1_code": [pd.NA, 2184, 1001],
+            "gaul2_code": [pd.NA, pd.NA, 100001],
+        }
+    )
+    monkeypatch.setattr(pygaul, "_df", lambda: df)
+    return df
+
+
+def test_admin0_returns_single_level(fake_gaul):
+    assert admin_mod.admin_parent_chain("ADMIN0", "197") == {0: "197"}
+
+
+def test_admin1_includes_parent_level0(fake_gaul):
+    assert admin_mod.admin_parent_chain("ADMIN1", "2184") == {0: "206", 1: "2184"}
+
+
+def test_admin2_includes_full_parent_chain(fake_gaul):
+    assert admin_mod.admin_parent_chain("ADMIN2", "100001") == {
+        0: "101",
+        1: "1001",
+        2: "100001",
+    }
+
+
+def test_unknown_code_returns_empty(fake_gaul):
+    assert admin_mod.admin_parent_chain("ADMIN0", "99999999") == {}
+
+
+def test_falsy_code_returns_empty(fake_gaul):
+    assert admin_mod.admin_parent_chain("ADMIN1", None) == {}
+    assert admin_mod.admin_parent_chain("ADMIN2", "") == {}
+
+
+def test_lookup_failure_returns_empty(monkeypatch):
+    def _boom():
+        raise RuntimeError("parquet unavailable")
+
+    monkeypatch.setattr(pygaul, "_df", _boom)
+    assert admin_mod.admin_parent_chain("ADMIN1", "2184") == {}

--- a/tests/test_solara/test_admin_selector_restore.py
+++ b/tests/test_solara/test_admin_selector_restore.py
@@ -1,0 +1,90 @@
+"""Regression tests for restoring a multi-level admin AOI cascade.
+
+Reproduces the bug where restoring a saved ADMIN1 selection (e.g.
+Paraguay > Amambay) left both cascade dropdowns empty: ``AoiView`` binds the
+selector's restore seed ``initial`` to the live ``admin_code`` reactive, which
+the selector itself resets to ``None`` (via ``update_output``) on mount before
+the async cascade seeds — wiping the restore chain.
+"""
+
+import time
+
+import solara
+
+import pysepal.solara.components.aoi.admin as admin_mod
+from pysepal.solara.components.inputs.admin_selector import AdminLevelSelector
+
+# Paraguay (206) > Amambay (2184); Algeria (101) > Adrar (1001) > Adrar (100001).
+_CHAINS = {
+    "2184": {0: "206", 1: "2184"},
+    "100001": {0: "101", 1: "1001", 2: "100001"},
+}
+
+
+def _fake_chain(method, code):
+    return dict(_CHAINS.get(str(code), {}))
+
+
+def _fake_fetch(level, parent_code):
+    # Mirrors fetch_admin_items' item shape.
+    mapping = {
+        (0, ""): [
+            {"text": "Paraguay", "value": "206"},
+            {"text": "Algeria", "value": "101"},
+        ],
+        (1, "206"): [{"text": "Amambay", "value": "2184"}],
+        (1, "101"): [{"text": "Adrar", "value": "1001"}],
+        (2, "1001"): [{"text": "Adrar", "value": "100001"}],
+    }
+    return mapping.get((level, str(parent_code)), [])
+
+
+@solara.component
+def _RestoreHarness(method, admin_code):
+    # Mirrors AoiView: the restore seed `initial` is bound live to the same
+    # reactive the selector drives.
+    AdminLevelSelector(
+        method=method,
+        gee=True,
+        value=admin_code,
+        initial=admin_code.value,
+    )
+
+
+def _settle(admin_code, expected, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline and admin_code.value != expected:
+        time.sleep(0.05)
+    # Give a redundant double-run a chance to wrongly wipe the value before asserting.
+    time.sleep(0.5)
+
+
+def test_admin1_cascade_restores_seeded_value(monkeypatch):
+    monkeypatch.setattr(admin_mod, "fetch_admin_items", _fake_fetch)
+    monkeypatch.setattr(admin_mod, "admin_parent_chain", _fake_chain, raising=False)
+
+    # The restored final code is present at mount (the app set it before mount).
+    admin_code = solara.reactive("2184")
+    box, rc = solara.render(_RestoreHarness("ADMIN1", admin_code), handle_error=False)
+    try:
+        _settle(admin_code, "2184")
+        assert admin_code.value == "2184", (
+            f"cascade failed to restore admin code; admin_code={admin_code.value!r}"
+        )
+    finally:
+        rc.close()
+
+
+def test_admin2_cascade_restores_full_chain(monkeypatch):
+    monkeypatch.setattr(admin_mod, "fetch_admin_items", _fake_fetch)
+    monkeypatch.setattr(admin_mod, "admin_parent_chain", _fake_chain, raising=False)
+
+    admin_code = solara.reactive("100001")
+    box, rc = solara.render(_RestoreHarness("ADMIN2", admin_code), handle_error=False)
+    try:
+        _settle(admin_code, "100001")
+        assert admin_code.value == "100001", (
+            f"ADMIN2 cascade failed to restore; admin_code={admin_code.value!r}"
+        )
+    finally:
+        rc.close()

--- a/tests/test_solara/test_admin_selector_restore.py
+++ b/tests/test_solara/test_admin_selector_restore.py
@@ -68,9 +68,9 @@ def test_admin1_cascade_restores_seeded_value(monkeypatch):
     box, rc = solara.render(_RestoreHarness("ADMIN1", admin_code), handle_error=False)
     try:
         _settle(admin_code, "2184")
-        assert admin_code.value == "2184", (
-            f"cascade failed to restore admin code; admin_code={admin_code.value!r}"
-        )
+        assert (
+            admin_code.value == "2184"
+        ), f"cascade failed to restore admin code; admin_code={admin_code.value!r}"
     finally:
         rc.close()
 
@@ -83,8 +83,8 @@ def test_admin2_cascade_restores_full_chain(monkeypatch):
     box, rc = solara.render(_RestoreHarness("ADMIN2", admin_code), handle_error=False)
     try:
         _settle(admin_code, "100001")
-        assert admin_code.value == "100001", (
-            f"ADMIN2 cascade failed to restore; admin_code={admin_code.value!r}"
-        )
+        assert (
+            admin_code.value == "100001"
+        ), f"ADMIN2 cascade failed to restore; admin_code={admin_code.value!r}"
     finally:
         rc.close()

--- a/tests/test_solara/test_aoi_admin.py
+++ b/tests/test_solara/test_aoi_admin.py
@@ -22,8 +22,20 @@ class _FakeAsyncInterface:
     def __init__(self):
         self.closed = False
         self.calls = []
+        self.async_calls = []
+        self.blocking_call_saw_running_loop = None
+
+    def get_info(self, payload):
+        try:
+            asyncio.get_running_loop()
+            self.blocking_call_saw_running_loop = True
+        except RuntimeError:
+            self.blocking_call_saw_running_loop = False
+        self.calls.append(payload)
+        return payload
 
     async def get_info_async(self, payload):
+        self.async_calls.append(payload)
         self.calls.append(payload)
         return payload
 
@@ -63,3 +75,23 @@ def test_process_admin_keeps_provided_interface_open(monkeypatch):
     assert result.admin == "62"
     assert interface.closed is False
     assert interface.calls == [{"iso3_code": "COL", "gaul0_name": "Colombia"}]
+
+
+def test_process_admin_keeps_gee_traffic_off_caller_loop(monkeypatch):
+    """process_admin must use the blocking GEE API from a worker thread.
+
+    eeclient caches one httpx.AsyncClient per session; its pooled HTTP/2
+    connection binds to the first event loop that drives it. Awaiting
+    get_info_async here runs that traffic on the Solara kernel loop, and any
+    later call routed through GEEInterface's private loop (e.g. add_ee_layer
+    -> get_map_id) then fails with "bound to a different event loop".
+    """
+    interface = _FakeAsyncInterface()
+
+    monkeypatch.setattr(admin.su, "init_ee", lambda: None)
+    monkeypatch.setattr(admin.pygaul, "Items", lambda admin=None: _FakeFeatureCollection())
+
+    asyncio.run(admin.process_admin("ADMIN0", "62", gee=True, gee_interface=interface))
+
+    assert interface.async_calls == []
+    assert interface.blocking_call_saw_running_loop is False

--- a/tests/test_solara/test_aoi_asset.py
+++ b/tests/test_solara/test_aoi_asset.py
@@ -111,3 +111,29 @@ def test_process_asset_raster_types(fake_ee, asset_type):
     result = _run(asset_mod.process_asset("users/me/raster_asset", asset_type=asset_type))
 
     assert isinstance(result.feature_collection, _FakeImage)
+
+
+def test_process_asset_attaches_selection_inputs(fake_ee):
+    """The result must round-trip the picker inputs so apps can restore it."""
+    result = _run(
+        asset_mod.process_asset(
+            "users/me/my_table",
+            asset_type="TABLE",
+            column="region",
+            value="north",
+        )
+    )
+
+    assert result.asset == {
+        "asset_id": "users/me/my_table",
+        "type": "TABLE",
+        "column": "region",
+        "value": "north",
+    }
+
+
+def test_aoi_result_asset_defaults_to_none():
+    from pysepal.solara.components.aoi import AoiResult
+
+    result = AoiResult(method="DRAW", name="drawn_item")
+    assert result.asset is None

--- a/tests/test_solara/test_aoi_view_restore.py
+++ b/tests/test_solara/test_aoi_view_restore.py
@@ -281,9 +281,11 @@ class _EeFakeMap(_FakeMap):
 
 
 def test_aoi_view_restore_adds_ee_layer_off_loop(monkeypatch):
-    """A restored GEE AOI must draw via the blocking add_ee_layer in a worker
-    thread — never add_ee_layer_async on the kernel loop (loop-bound eeclient
-    pool; see _EeFakeMap)."""
+    """A restored GEE AOI must draw via the blocking add_ee_layer in a worker thread.
+
+    Never add_ee_layer_async on the kernel loop (loop-bound eeclient pool; see
+    _EeFakeMap).
+    """
     _patch_admin(monkeypatch)
     monkeypatch.setattr(aoi_view_mod, "get_current_gee_interface", lambda: object())
 

--- a/tests/test_solara/test_aoi_view_restore.py
+++ b/tests/test_solara/test_aoi_view_restore.py
@@ -117,13 +117,13 @@ def test_aoi_view_restores_every_method_from_value(monkeypatch, result):
                 lambda b: _has_v_model(b, result.method),
                 lambda b: _has_text(b, ms.aoi_sel.complete),
             )
-            assert _has_v_model(box, result.method), (
-                f"method select was not seeded with {result.method}"
-            )
+            assert _has_v_model(
+                box, result.method
+            ), f"method select was not seeded with {result.method}"
             # The auto-select must land the panel in the confirmed state.
-            assert _has_text(box, ms.aoi_sel.complete), (
-                f"restored {result.method} AOI was not auto-confirmed"
-            )
+            assert _has_text(
+                box, ms.aoi_sel.complete
+            ), f"restored {result.method} AOI was not auto-confirmed"
             # The restore must keep the loaded AOI, not clear or rebuild it.
             assert value.value is result
         finally:
@@ -175,9 +175,7 @@ def test_aoi_view_restores_draw_name_and_editable_geometry(monkeypatch):
     value = solara.reactive(result)
 
     async def _scenario():
-        box, rc = solara.render(
-            AoiView(value=value, gee=False, map_=map_), handle_error=False
-        )
+        box, rc = solara.render(AoiView(value=value, gee=False, map_=map_), handle_error=False)
         try:
             await _settle(
                 box,
@@ -234,9 +232,7 @@ class _FakeGeeInterface:
 def test_aoi_view_restores_asset_selection(monkeypatch):
     _patch_admin(monkeypatch)
     monkeypatch.setattr(aoi_view_mod.su, "init_ee", lambda: None)
-    monkeypatch.setattr(
-        aoi_view_mod, "get_current_gee_interface", lambda: _FakeGeeInterface()
-    )
+    monkeypatch.setattr(aoi_view_mod, "get_current_gee_interface", lambda: _FakeGeeInterface())
 
     asset = {"asset_id": "users/me/aoi", "type": "TABLE", "column": "ALL", "value": None}
     result = AoiResult(method="ASSET", name="aoi", gee=True, asset=asset)

--- a/tests/test_solara/test_aoi_view_restore.py
+++ b/tests/test_solara/test_aoi_view_restore.py
@@ -11,6 +11,7 @@ reprocessing.
 """
 
 import asyncio
+import threading
 import time
 
 import geopandas as gpd
@@ -252,6 +253,60 @@ def test_aoi_view_restores_asset_selection(monkeypatch):
             assert _has_v_model(box, "users/me/aoi"), "asset id was not restored"
             assert _has_text(box, ms.aoi_sel.complete), "restored ASSET AOI was not auto-confirmed"
             assert value.value is result
+        finally:
+            rc.close()
+
+    asyncio.run(_scenario())
+
+
+class _EeFakeMap(_FakeMap):
+    """SepalMap stand-in for GEE results: records how the EE layer was added.
+
+    ``add_ee_layer_async`` reproduces the crash seen after a project load:
+    eeclient's pooled HTTP/2 connection binds to the loop that first used it
+    (GEEInterface's private loop, warmed by the load's sync-API traffic), so
+    awaiting the async path from Solara's kernel loop raises RuntimeError.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.ee_threads = []
+
+    def add_ee_layer(self, ee_object, vis_params={}, name="", **kwargs):
+        self.ee_threads.append(threading.current_thread())
+        self.layers.append(name or "ee")
+
+    async def add_ee_layer_async(self, *args, **kwargs):
+        raise RuntimeError("<asyncio.locks.Event [unset]> is bound to a different event loop")
+
+
+def test_aoi_view_restore_adds_ee_layer_off_loop(monkeypatch):
+    """A restored GEE AOI must draw via the blocking add_ee_layer in a worker
+    thread — never add_ee_layer_async on the kernel loop (loop-bound eeclient
+    pool; see _EeFakeMap)."""
+    _patch_admin(monkeypatch)
+    monkeypatch.setattr(aoi_view_mod, "get_current_gee_interface", lambda: object())
+
+    map_ = _EeFakeMap()
+    result = AoiResult(
+        method="DRAW",
+        name="my_drawing",
+        gdf=_gdf(),
+        gee=True,
+        feature_collection=object(),
+    )
+    value = solara.reactive(result)
+
+    async def _scenario():
+        loop_thread = threading.current_thread()
+        box, rc = solara.render(AoiView(value=value, gee=True, map_=map_), handle_error=False)
+        try:
+            await _settle(box, lambda b: _has_text(b, ms.aoi_sel.complete))
+            assert _has_text(box, ms.aoi_sel.complete), "restored GEE AOI was not auto-confirmed"
+            assert map_.layers, "restored EE layer was not drawn on the map"
+            assert map_.ee_threads and all(
+                t is not loop_thread for t in map_.ee_threads
+            ), "add_ee_layer ran on the kernel event loop thread"
         finally:
             rc.close()
 

--- a/tests/test_solara/test_aoi_view_restore.py
+++ b/tests/test_solara/test_aoi_view_restore.py
@@ -1,0 +1,262 @@
+"""AoiView must restore its picker state from a pre-populated ``value`` at mount.
+
+Apps that persist AOI selections (project save/load) rebuild an ``AoiResult``
+and pass it as ``value`` when remounting ``AoiView``. Without restore support
+the picker renders blank (method select empty) even though ``value`` is set.
+
+Covers every selection method: the picker must seed its method select (plus
+the method-specific inputs it can) and auto-confirm the restored AOI — the
+success feedback is the observable proof the auto-select ran without
+reprocessing.
+"""
+
+import asyncio
+import time
+
+import geopandas as gpd
+import pytest
+import solara
+from shapely.geometry import box as shapely_box
+
+import pysepal.solara.components.aoi.admin as admin_mod
+import pysepal.solara.components.aoi.aoi_view as aoi_view_mod
+from pysepal.message import ms
+from pysepal.solara.components.aoi import AoiResult
+from pysepal.solara.components.aoi.aoi_view import AoiView
+
+
+def _fake_fetch(level, parent_code):
+    mapping = {
+        (0, ""): [
+            {"text": "Paraguay", "value": "206"},
+            {"text": "Algeria", "value": "101"},
+        ],
+        (1, "206"): [{"text": "Amambay", "value": "2184"}],
+        (1, "101"): [{"text": "Adrar", "value": "1001"}],
+        (2, "1001"): [{"text": "Adrar", "value": "100001"}],
+    }
+    return mapping.get((level, str(parent_code)), [])
+
+
+_CHAINS = {
+    "197": {0: "197"},
+    "206": {0: "206"},
+    "2184": {0: "206", 1: "2184"},
+    "100001": {0: "101", 1: "1001", 2: "100001"},
+}
+
+
+def _fake_chain(method, code):
+    return dict(_CHAINS.get(str(code), {}))
+
+
+def _gdf():
+    return gpd.GeoDataFrame(
+        {"name": ["aoi"]}, geometry=[shapely_box(12.40, 43.89, 12.52, 43.99)], crs="EPSG:4326"
+    )
+
+
+def _widgets(root):
+    """Depth-first walk over an ipywidgets tree."""
+    seen = set()
+    stack = [root]
+    while stack:
+        widget = stack.pop()
+        if id(widget) in seen:
+            continue
+        seen.add(id(widget))
+        yield widget
+        stack.extend(getattr(widget, "children", ()) or ())
+
+
+def _has_v_model(root, expected):
+    return any(getattr(w, "v_model", None) == expected for w in _widgets(root))
+
+
+def _has_text(root, expected):
+    for w in _widgets(root):
+        for child in getattr(w, "children", ()) or ():
+            if isinstance(child, str) and expected in child:
+                return True
+    return False
+
+
+async def _settle(box, *predicates, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline and not all(p(box) for p in predicates):
+        await asyncio.sleep(0.05)
+
+
+def _patch_admin(monkeypatch):
+    monkeypatch.setattr(admin_mod, "fetch_admin_items", _fake_fetch)
+    monkeypatch.setattr(admin_mod, "admin_parent_chain", _fake_chain, raising=False)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        AoiResult(method="ADMIN0", name="Paraguay", admin="206", gee=False),
+        AoiResult(method="ADMIN1", name="Amambay", admin="2184", gee=False),
+        AoiResult(method="ADMIN2", name="Adrar", admin="100001", gee=False),
+        AoiResult(method="SHAPE", name="my_shape", gdf=_gdf(), gee=False),
+        AoiResult(method="POINTS", name="my_points", gdf=_gdf(), gee=False),
+        AoiResult(method="DRAW", name="my_drawing", gdf=_gdf(), gee=False),
+    ],
+    ids=lambda r: r.method,
+)
+def test_aoi_view_restores_every_method_from_value(monkeypatch, result):
+    _patch_admin(monkeypatch)
+
+    value = solara.reactive(result)
+
+    async def _scenario():
+        box, rc = solara.render(AoiView(value=value, gee=False), handle_error=False)
+        try:
+            await _settle(
+                box,
+                lambda b: _has_v_model(b, result.method),
+                lambda b: _has_text(b, ms.aoi_sel.complete),
+            )
+            assert _has_v_model(box, result.method), (
+                f"method select was not seeded with {result.method}"
+            )
+            # The auto-select must land the panel in the confirmed state.
+            assert _has_text(box, ms.aoi_sel.complete), (
+                f"restored {result.method} AOI was not auto-confirmed"
+            )
+            # The restore must keep the loaded AOI, not clear or rebuild it.
+            assert value.value is result
+        finally:
+            rc.close()
+
+    asyncio.run(_scenario())
+
+
+class _FakeDrawControl:
+    def __init__(self):
+        self.data = []
+
+    def clear(self):
+        pass
+
+    def to_json(self):
+        return {"features": self.data}
+
+
+class _FakeMap:
+    """Minimal SepalMap stand-in: draw control + layer/control bookkeeping."""
+
+    def __init__(self):
+        self.dc = _FakeDrawControl()
+        self.controls = []
+        self.layers = []
+
+    def add_control(self, control):
+        self.controls.append(control)
+
+    def remove_control(self, control):
+        self.controls.remove(control)
+
+    def add_layer(self, layer, key=None):
+        self.layers.append(layer)
+
+    def remove_layer(self, layer):
+        self.layers.remove(layer)
+
+    def zoom_bounds(self, bounds):
+        pass
+
+
+def test_aoi_view_restores_draw_name_and_editable_geometry(monkeypatch):
+    _patch_admin(monkeypatch)
+
+    map_ = _FakeMap()
+    result = AoiResult(method="DRAW", name="my_drawing", gdf=_gdf(), gee=False)
+    value = solara.reactive(result)
+
+    async def _scenario():
+        box, rc = solara.render(
+            AoiView(value=value, gee=False, map_=map_), handle_error=False
+        )
+        try:
+            await _settle(
+                box,
+                lambda b: _has_v_model(b, "my_drawing"),
+                lambda b: _has_text(b, ms.aoi_sel.complete),
+            )
+            # The DRAW name field must be seeded with the restored AOI name.
+            assert _has_v_model(box, "my_drawing"), "draw name field was not restored"
+            assert _has_text(box, ms.aoi_sel.complete), "restored DRAW AOI was not auto-confirmed"
+            # The DrawControl must be re-populated so the restored AOI is editable,
+            # and the geometry re-rendered on the map by the auto-select.
+            assert map_.dc.data, "DrawControl was not re-seeded from the restored gdf"
+            assert map_.layers, "restored AOI layer was not drawn on the map"
+        finally:
+            rc.close()
+
+    asyncio.run(_scenario())
+
+
+def test_aoi_view_restores_admin_cascade_code(monkeypatch):
+    _patch_admin(monkeypatch)
+
+    result = AoiResult(method="ADMIN1", name="Amambay", admin="2184", gee=False)
+    value = solara.reactive(result)
+
+    async def _scenario():
+        box, rc = solara.render(AoiView(value=value, gee=False), handle_error=False)
+        try:
+            # Both cascade levels must end up selected (parent + final code).
+            await _settle(
+                box,
+                lambda b: _has_v_model(b, "206"),
+                lambda b: _has_v_model(b, "2184"),
+            )
+            assert _has_v_model(box, "206"), "cascade parent (level 0) was not restored"
+            assert _has_v_model(box, "2184"), "cascade final code (level 1) was not restored"
+        finally:
+            rc.close()
+
+    asyncio.run(_scenario())
+
+
+class _FakeGeeInterface:
+    async def get_folder_async(self):
+        return "users/me"
+
+    async def get_assets_async(self, folder):
+        return []
+
+    async def get_asset_async(self, asset_id):
+        raise ValueError("no GEE access in tests")
+
+
+def test_aoi_view_restores_asset_selection(monkeypatch):
+    _patch_admin(monkeypatch)
+    monkeypatch.setattr(aoi_view_mod.su, "init_ee", lambda: None)
+    monkeypatch.setattr(
+        aoi_view_mod, "get_current_gee_interface", lambda: _FakeGeeInterface()
+    )
+
+    asset = {"asset_id": "users/me/aoi", "type": "TABLE", "column": "ALL", "value": None}
+    result = AoiResult(method="ASSET", name="aoi", gee=True, asset=asset)
+    value = solara.reactive(result)
+
+    async def _scenario():
+        box, rc = solara.render(AoiView(value=value, gee=True), handle_error=False)
+        try:
+            await _settle(
+                box,
+                lambda b: _has_v_model(b, "ASSET"),
+                lambda b: _has_v_model(b, "users/me/aoi"),
+                lambda b: _has_text(b, ms.aoi_sel.complete),
+            )
+            assert _has_v_model(box, "ASSET"), "method select was not seeded with ASSET"
+            # The asset combobox must be seeded from AoiResult.asset.
+            assert _has_v_model(box, "users/me/aoi"), "asset id was not restored"
+            assert _has_text(box, ms.aoi_sel.complete), "restored ASSET AOI was not auto-confirmed"
+            assert value.value is result
+        finally:
+            rc.close()
+
+    asyncio.run(_scenario())

--- a/tests/test_solara/test_aoi_view_unmount.py
+++ b/tests/test_solara/test_aoi_view_unmount.py
@@ -92,9 +92,7 @@ def test_unmount_still_releases_owned_resources():
             rc.render(_Host(value=value, show=False, map_=map_, loading=loading))
             await asyncio.sleep(0.5)
 
-            aoi_layers = [
-                layer for layer in map_.layers if getattr(layer, "name", None) == "aoi"
-            ]
+            aoi_layers = [layer for layer in map_.layers if getattr(layer, "name", None) == "aoi"]
             assert not aoi_layers, "unmount left the AOI layer on the map"
             assert map_.dc not in map_.controls, "unmount left the DrawControl attached"
             assert loading.value is False, "unmount left the loading flag set"

--- a/tests/test_solara/test_aoi_view_unmount.py
+++ b/tests/test_solara/test_aoi_view_unmount.py
@@ -1,0 +1,104 @@
+"""Unmounting AoiView must not erase the caller's AOI state.
+
+``value`` may be a reactive owned by the host app (``solara.use_reactive``
+passes a reactive straight through), so anything AoiView writes to it lands in
+application state. Tearing the picker down — a collapsed panel, a conditional
+render, a keyed remount — is a lifecycle event of the *widget*, not a user
+decision to drop the AOI. Clearing ``value`` there silently destroys a
+selection the app is still holding (and, for apps that persist it, saves an
+empty AOI over a good one).
+
+AoiView still owns the map layers, draw control and loading flag it created,
+so unmount must keep releasing those.
+"""
+
+import asyncio
+
+import geopandas as gpd
+import solara
+from shapely.geometry import box as shapely_box
+
+from pysepal.solara.components.aoi import AoiResult
+from pysepal.solara.components.aoi.aoi_view import AoiView
+
+from .test_aoi_view_restore import _FakeMap
+
+
+def _gdf():
+    return gpd.GeoDataFrame(
+        {"name": ["aoi"]},
+        geometry=[shapely_box(12.40, 43.89, 12.52, 43.99)],
+        crs="EPSG:4326",
+    )
+
+
+@solara.component
+def _Host(value, show, map_, loading):
+    """A host that mounts the picker behind a toggle, as a collapsible panel would."""
+    with solara.Column():
+        if show:
+            AoiView(value=value, loading=loading, gee=False, map_=map_, methods="ALL")
+        else:
+            solara.Text("picker hidden")
+
+
+def _run(scenario):
+    asyncio.run(scenario())
+
+
+def test_unmount_keeps_caller_owned_value():
+    """The host's AOI reactive must survive the picker being unmounted."""
+    map_ = _FakeMap()
+    value = solara.reactive(AoiResult(method="DRAW", name="my_drawing", gdf=_gdf()))
+    loading = solara.reactive(False)
+
+    async def scenario():
+        box, rc = solara.render(
+            _Host(value=value, show=True, map_=map_, loading=loading),
+            handle_error=False,
+        )
+        try:
+            await asyncio.sleep(0.5)
+            assert value.value is not None, "precondition: AOI is set while mounted"
+
+            rc.render(_Host(value=value, show=False, map_=map_, loading=loading))
+            await asyncio.sleep(0.5)
+
+            assert value.value is not None, (
+                "unmount cleared the caller's AOI reactive; the host app lost its "
+                "selection just because the picker was torn down"
+            )
+            assert value.value.name == "my_drawing"
+        finally:
+            rc.close()
+
+    _run(scenario)
+
+
+def test_unmount_still_releases_owned_resources():
+    """Unmount must keep tearing down what AoiView itself put on the map."""
+    map_ = _FakeMap()
+    value = solara.reactive(AoiResult(method="DRAW", name="my_drawing", gdf=_gdf()))
+    loading = solara.reactive(True)
+
+    async def scenario():
+        box, rc = solara.render(
+            _Host(value=value, show=True, map_=map_, loading=loading),
+            handle_error=False,
+        )
+        try:
+            await asyncio.sleep(0.8)
+
+            rc.render(_Host(value=value, show=False, map_=map_, loading=loading))
+            await asyncio.sleep(0.5)
+
+            aoi_layers = [
+                layer for layer in map_.layers if getattr(layer, "name", None) == "aoi"
+            ]
+            assert not aoi_layers, "unmount left the AOI layer on the map"
+            assert map_.dc not in map_.controls, "unmount left the DrawControl attached"
+            assert loading.value is False, "unmount left the loading flag set"
+        finally:
+            rc.close()
+
+    _run(scenario)


### PR DESCRIPTION
## Problem

The Solara `AoiView` cannot be programmatically restored: passing a rebuilt `AoiResult` as `value` renders a blank picker (method select empty, admin cascade unseeded, asset field empty). Apps that persist AOI selections across sessions (project save/load) currently have to vendor the component to get restore-on-load. The legacy sepalwidgets `AoiModel` already supports this via its `vector`/`admin`/`asset` constructor defaults — this PR brings the Solara component to parity.

## Changes

- **AoiView**: when `value` holds an `AoiResult` at mount, seed the method select, admin cascade, draw name/control and asset field from it, then auto-confirm the selection (map layer + success feedback) reusing the loaded result instead of reprocessing. Guards cover reacton's double effect-run and value churn during load-triggered remounts.
- **AdminLevelSelector**: new `initial` seed restores the full cascade from the final admin code via `admin_parent_chain()` (GAUL parquet lookup in `aoi/admin.py`).
- **AssetSelectComponent**: new `initial` seed re-applies a persisted `{asset_id, type, column, value}` selection (asset id validated and columns loaded as if picked, column/value seeded once the columns arrive).
- **AoiResult**: new `asset` field round-trips the asset picker inputs (populated by `process_asset`) so ASSET selections can be persisted and restored without a side-channel. Appended last with a default — fully backward compatible.

All new parameters are optional; existing apps are unaffected. The legacy `pysepal.aoi` (sepalwidgets) stack is untouched.

## Tests

Hermetic — no network or EE access (pygaul lookups and admin fetches mocked, fake GEE interface for the asset flow):

- `test_aoi_view_restore.py` — restore across every method (ADMIN0/1/2, SHAPE, POINTS, DRAW, ASSET): method select seeded, auto-confirm reached, loaded value preserved. DRAW additionally re-seeds the DrawControl (restored AOI stays editable) and re-draws the map layer; ADMIN1 restores both cascade levels; ASSET seeds the combobox from `AoiResult.asset`.
- `test_admin_selector_restore.py` — regression: the ADMIN1/ADMIN2 cascade must survive `initial` being bound to the live reactive the selector drives (whose mount-time reset wiped the chain) and reacton's double effect-run.
- `test_admin_parent_chain.py` — parent-chain lookup unit tests (mocked `pygaul._df`), including unknown/falsy codes and lookup failure returning `{}`.
- `test_aoi_asset.py` — `process_asset` attaches the selection inputs; `AoiResult.asset` defaults to `None`.

`tests/test_solara`: 188 passed on this branch. Legacy `tests/test_aoi`: unaffected, passing.