### PR TITLE
feat(scripts): add --click and --resize to browser_probe

### DIFF
--- a/docs/guides/browser-testing.md
+++ b/docs/guides/browser-testing.md
@@ -56,6 +56,34 @@ node scripts/browser_probe.mjs --url http://127.0.0.1:8910/ --wait '.pill-wrappe
 diff <(jq -S . /tmp/solara.json) <(jq -S . /tmp/voila.json)
 ```
 
+## Interacting before you measure
+
+Some questions are only answerable by _doing_ something first — does clicking
+outside dismiss this dialog, does the scrim resize cleanly. `--click` and
+`--resize` run before `--eval`, so the expression measures the result:
+
+```bash
+# does clicking outside dismiss the dialog?
+node scripts/browser_probe.mjs --url http://127.0.0.1:8900/ \
+  --wait '.v-dialog--active' --click 12,-12 --settle-after 1500 \
+  --eval "({ open: !!document.querySelector('.v-dialog--active') })"
+
+# does the scrim track a viewport resize, or animate to it?
+node scripts/browser_probe.mjs --url http://127.0.0.1:8900/ \
+  --wait '.v-overlay' --resize 1000x700 --settle-after 50 \
+  --eval "(() => { const r = document.querySelector('.v-overlay__scrim').getBoundingClientRect();
+                   return { w: Math.round(r.width), vw: window.innerWidth }; })()"
+```
+
+**Use `--click` rather than clicking from `--eval`.** A click dispatched from JS
+(`el.click()`, `new MouseEvent(...)`) is untrusted, and vuetify's click-outside
+directive drops untrusted events on purpose (`if ('isTrusted' in e && !e.isTrusted) return false`). Driving it from `--eval` will tell you that
+dismissing a dialog is broken when it works perfectly.
+
+`--settle-after` defaults to 1200ms because widget round-trips go through the
+python kernel — far slower than a repaint. If a result looks negative, raise it
+before concluding anything.
+
 ## Writing a probe
 
 A probe is **one JavaScript expression** evaluated in the page. Read the DOM and
@@ -83,16 +111,19 @@ Pass it inline with `--eval "(...)"` or from a file with `--eval @path/to/probe.
 
 ## Options
 
-| Flag                        | Meaning                                                                                |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| `--url <url>`               | **required** — page to load                                                            |
-| `--eval <expr\|@file>`      | expression to evaluate (or `@file`); must return JSON-serializable data                |
-| `--wait <selector>`         | poll until this selector exists (else `--timeout`)                                     |
-| `--settle <ms>`             | extra wait after ready, for layout/theme (default 2000)                                |
-| `--timeout <ms>`            | readiness budget (default 30000)                                                       |
-| `--force-theme dark\|light` | set `:solara:theme.variant` in localStorage and reload (Solara only; Voila ignores it) |
-| `--chrome <path>`           | Chrome binary (default: autodetect)                                                    |
-| `--keep-open`               | leave Chrome running (to debug the probe itself)                                       |
+| Flag                        | Meaning                                                                                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--url <url>`               | **required** — page to load                                                                                                                             |
+| `--eval <expr\|@file>`      | expression to evaluate (or `@file`); must return JSON-serializable data                                                                                 |
+| `--wait <selector>`         | poll until this selector exists (else `--timeout`)                                                                                                      |
+| `--settle <ms>`             | extra wait after ready, for layout/theme (default 2000)                                                                                                 |
+| `--click <x,y\|selector>`   | issue a **real (trusted)** click before `--eval` — coordinates, or the centre of a selector. Negative coordinates count back from the right/bottom edge |
+| `--resize <WxH>`            | resize the viewport before `--eval` (e.g. `1000x700`)                                                                                                   |
+| `--settle-after <ms>`       | wait after `--click`/`--resize` (default 1200)                                                                                                          |
+| `--timeout <ms>`            | readiness budget (default 30000)                                                                                                                        |
+| `--force-theme dark\|light` | set `:solara:theme.variant` in localStorage and reload (Solara only; Voila ignores it)                                                                  |
+| `--chrome <path>`           | Chrome binary (default: autodetect)                                                                                                                     |
+| `--keep-open`               | leave Chrome running (to debug the probe itself)                                                                                                        |
 
 ## Worked example: the Solara/Voila theme-parity hunt
 
@@ -124,6 +155,14 @@ Each conclusion came from a computed-style read, not a guess.
   affected by ancestor classes from the host page (Jupyter sets `theme-light`
   on `<body>`). Probe computed styles to catch this; prefer child combinators or
   namespaced classes in `.vue` theme rules.
+- **The viewport is not `--window-size`.** Headless Chrome may report a much
+  smaller `window.innerHeight` than the window you asked for. Derive click
+  coordinates from `window.innerWidth/innerHeight` — which `--click` does for
+  you — instead of hardcoding, or you will click past the page and hit `<html>`.
+- **Bind dialogs with a real two-way model.** A fixture built with a constant
+  (ipyvuetify `Dialog(v_model=True)` with no handler) reopens the instant
+  vuetify closes it, so it can never _appear_ to dismiss. Use a reactive plus
+  `on_v_model` or you will measure your own fixture.
 - **Theme defaults differ.** Solara defaults dark via a `localStorage` flag that
   applies on the _next_ load; a first headless load may render light. Use
   `--force-theme dark` (Solara) or drive the app's own theme toggle.

--- a/scripts/browser_probe.mjs
+++ b/scripts/browser_probe.mjs
@@ -26,6 +26,11 @@
  *   node scripts/browser_probe.mjs --url http://127.0.0.1:8910/ \
  *        --eval "({ title: document.title })"
  *
+ *   # dismiss a dialog by clicking the scrim, then check it actually closed
+ *   node scripts/browser_probe.mjs --url http://127.0.0.1:8900/ \
+ *        --wait '.v-dialog--active' --click 12,-12 --settle-after 1500 \
+ *        --eval "({ open: !!document.querySelector('.v-dialog--active') })"
+ *
  * Options
  * -------
  *   --url <url>          (required) page to load
@@ -35,6 +40,14 @@
  *                        + body text length.
  *   --wait <selector>    poll until this selector exists (else --timeout)
  *   --settle <ms>        extra wait after ready, for layout/theme (default 2000)
+ *   --click <x,y|sel>    issue a REAL (trusted) click before --eval, either at
+ *                        viewport coordinates or at the centre of a selector.
+ *                        Negative coordinates count back from the right/bottom
+ *                        edge, so `12,-12` is 12px in from the bottom-left.
+ *   --resize <WxH>       resize the viewport before --eval (e.g. 1000x700)
+ *   --settle-after <ms>  wait after --click/--resize (default 1200). Widget
+ *                        round-trips go through the python kernel, so a UI
+ *                        change can take far longer than a repaint.
  *   --timeout <ms>       readiness budget (default 30000)
  *   --force-theme <t>    set localStorage ':solara:theme.variant' to "dark" or
  *                        "light" and reload (Solara only — Voila ignores it)
@@ -51,6 +64,13 @@
  *     own shell. This tool tracks the spawned PID and kills only that.
  *   - Inside a restricted sandbox Chrome may be signal-killed on launch; run it
  *     from a normal shell, or disable the sandbox for the launching command.
+ *   - A click dispatched from JS (`el.click()`, `new MouseEvent(...)`) is NOT
+ *     trusted, and vuetify's click-outside directive drops untrusted events on
+ *     purpose. Use --click, which goes through CDP `Input.dispatchMouseEvent`,
+ *     or you will "prove" that dismissing a dialog is broken when it is not.
+ *   - The headless viewport is NOT the --window-size: derive click coordinates
+ *     from `window.innerWidth/innerHeight` (which --click does) rather than
+ *     hardcoding, or you will click outside the page and hit <html>.
  *   - ipyvue injects Vue `<style scoped>` as GLOBAL css (no data-v attribute),
  *     so computed styles can be affected by ancestor classes you don't expect
  *     (e.g. JupyterLab sets `theme-light` on <body>). Probing computed styles
@@ -77,6 +97,9 @@ const SETTLE = parseInt(argVal("--settle", "2000"), 10);
 const TIMEOUT = parseInt(argVal("--timeout", "30000"), 10);
 const FORCE_THEME = argVal("--force-theme");
 const KEEP_OPEN = process.argv.includes("--keep-open");
+const CLICK = argVal("--click");
+const RESIZE = argVal("--resize");
+const SETTLE_AFTER = parseInt(argVal("--settle-after", "1200"), 10);
 let EVAL = argVal("--eval");
 if (EVAL && EVAL.startsWith("@")) EVAL = readFileSync(EVAL.slice(1), "utf8");
 if (!EVAL)
@@ -261,6 +284,61 @@ async function main() {
     await send(ws, "Page.reload", {}, sessionId);
     await waitReady();
     await sleep(SETTLE);
+  }
+
+  if (RESIZE) {
+    const m = /^(\d+)x(\d+)$/.exec(RESIZE);
+    if (!m) throw new Error(`--resize expects WxH, got "${RESIZE}"`);
+    await send(
+      ws,
+      "Emulation.setDeviceMetricsOverride",
+      {
+        width: parseInt(m[1], 10),
+        height: parseInt(m[2], 10),
+        deviceScaleFactor: 1,
+        mobile: false,
+      },
+      sessionId
+    );
+    await sleep(SETTLE_AFTER);
+  }
+
+  if (CLICK) {
+    // Resolve to viewport coordinates in the page, so the caller never has to
+    // guess the headless viewport size.
+    const point = await evaluate(
+      ws,
+      sessionId,
+      `(() => {
+        const spec = ${JSON.stringify(CLICK)};
+        const coords = /^(-?\\d+),(-?\\d+)$/.exec(spec);
+        if (coords) {
+          const x = +coords[1], y = +coords[2];
+          return { x: x < 0 ? window.innerWidth + x : x,
+                   y: y < 0 ? window.innerHeight + y : y };
+        }
+        const el = document.querySelector(spec);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { x: Math.round(r.left + r.width / 2), y: Math.round(r.top + r.height / 2) };
+      })()`
+    );
+    if (!point) throw new Error(`--click found no element for "${CLICK}"`);
+
+    for (const type of ["mouseMoved", "mousePressed", "mouseReleased"]) {
+      await send(
+        ws,
+        "Input.dispatchMouseEvent",
+        {
+          type,
+          x: point.x,
+          y: point.y,
+          ...(type === "mouseMoved" ? {} : { button: "left", clickCount: 1 }),
+        },
+        sessionId
+      );
+    }
+    await sleep(SETTLE_AFTER);
   }
 
   const value = await evaluate(ws, sessionId, EVAL);


### PR DESCRIPTION
`browser_probe.mjs` could only evaluate an expression, so any "does clicking this do X" question had to dispatch the click from `--eval`. That doesn't work: a click made from JS (`el.click()`, `new MouseEvent(...)`) is untrusted, and vuetify's click-outside directive drops untrusted events by design —

```js
if (('isTrusted' in e && !e.isTrusted) || ('pointerType' in e && !e.pointerType)) return false
```

so the probe reports "the dialog didn't close" for behaviour that works perfectly. That cost real time while debugging #1018: synthetic clicks failed in *every* configuration including vanilla vuetify, so the harness looked informative while proving nothing.

**`--click <x,y|selector>`** goes through CDP `Input.dispatchMouseEvent`, producing a genuinely trusted `PointerEvent`. It takes coordinates or a selector (whose centre it computes), and resolves both **against the live viewport** — headless Chrome's `window.innerHeight` is not the requested `--window-size`, and hardcoding coordinates lands you outside the page on `<html>`. Negative values count back from the right/bottom edge, so `12,-12` is 12px in from the bottom-left.

**`--resize <WxH>`** covers geometry questions — whether an overlay tracks a viewport change or animates to it. That's how the scrim's 296ms resize lag got measured.

**`--settle-after <ms>`** (default 1200) waits after either, because widget round-trips go through the python kernel and are far slower than a repaint.

```bash
# does clicking outside dismiss the dialog?
node scripts/browser_probe.mjs --url http://127.0.0.1:8900/ \
  --wait '.v-dialog--active' --click 12,-12 --settle-after 1500 \
  --eval "({ open: !!document.querySelector('.v-dialog--active') })"
```

Verified against a running app: `--click '.sepal-legend__bar'` flips `collapsed false → true` and drops `.sepal-legend__body`, both forms resolve correctly, and bad input fails loudly (`--click found no element for ".does-not-exist"`, `--resize expects WxH`). It also independently reproduces the layering bug #1018 fixes — on `main` a bottom-left click lands on `leaflet-control-attribution`, because the map's `z-index: 800` covers the scrim's `201`.

The guide gains an "Interacting before you measure" section and three gotchas: untrusted clicks, the viewport-vs-window-size trap, and the fixture trap where an ipyvuetify `Dialog(v_model=True)` with no handler reopens the instant vuetify closes it — so it can never appear to dismiss, and you measure your own fixture.

No behaviour change to existing probes; the new flags are opt-in and skipped when absent.
