### PR TITLE
feat: browser-owned locale resolution for pysepal 4.0

### DIFF
--- a/demo_apps/solara_map_app/app.py
+++ b/demo_apps/solara_map_app/app.py
@@ -9,6 +9,7 @@ This module is only the shell: it opens the session, holds the reactives the
 sections share and lays them out. The pieces live under ``component/``:
 
 - ``component/parameter`` -- layer ids, vis params, class breaks, sample paths
+- ``component/message`` -- the locale-following translator
 - ``component/model`` -- the app model and the dataclasses carried in reactives
 - ``component/scripts`` -- Earth Engine work, legend numbers, export sources (no UI)
 - ``component/tile`` -- the right-panel sections
@@ -26,6 +27,7 @@ pysepal$ ./run_solara.sh demo_apps/solara_map_app/app.py --port 8901
 """
 
 import solara
+from component.message import use_translator
 from component.parameter import DUMMY_DATA_DIR
 from component.tile import ExportPanel, ProcessPanel, use_layer_tools
 from component.widget import MapLegend, use_aoi_scoped_layers, use_sepal_map
@@ -61,6 +63,10 @@ def MapAppDemo():
     drive_interface = get_current_drive_interface()
     theme_state = get_current_theme_state()
 
+    # Rebuilt whenever the app-bar picker resolves a new locale, so a language
+    # change re-renders in place -- no page reload, and no ~/.sepal-ui-config.
+    cm = use_translator()
+
     # State shared between the sections; each section owns whatever is private to it.
     aoi_data = solara.use_reactive(None)
     aoi_loading = solara.use_reactive(False)
@@ -81,20 +87,20 @@ def MapAppDemo():
     )
 
     right_panel_config = {
-        "title": "Tools",
+        "title": cm.panel.title,
         "icon": "mdi-map-marker-check",
         "width": 400,
-        "description": "Select an area, process it, then inspect and export the results.",
+        "description": cm.panel.description,
     }
 
     right_panel_content = [
         {
-            "title": "Select AOI",
+            "title": cm.section.aoi.title,
             "icon": "mdi-map-marker-check",
             "content": [aoi_view],
         },
         {
-            "title": "Process",
+            "title": cm.section.process.title,
             "icon": "mdi-cog-outline",
             "content": [
                 ProcessPanel(
@@ -105,20 +111,17 @@ def MapAppDemo():
                     gee_interface=gee_interface,
                 )
             ],
-            "description": "Derives two layers from the AOI and publishes a legend for each.",
+            "description": cm.section.process.description,
         },
         {
-            "title": "Layers",
+            "title": cm.section.layers.title,
             "icon": "mdi-layers",
             "content": layer_tools,
-            "description": (
-                "Add a standalone demo layer or a PMTiles vector layer, or clear the map "
-                "and its legends. Both show up in the layer control, top right."
-            ),
+            "description": cm.section.layers.description,
             "divider": True,
         },
         {
-            "title": "Export",
+            "title": cm.section.export.title,
             "icon": "mdi-export-variant",
             "content": [
                 ExportPanel(
@@ -128,7 +131,7 @@ def MapAppDemo():
                     drive_interface=drive_interface,
                 )
             ],
-            "description": "Send the AOI or a processed output to Earth Engine, Drive or SEPAL.",
+            "description": cm.section.export.description,
         },
     ]
 
@@ -138,7 +141,7 @@ def MapAppDemo():
     MapLegend(layer_legends)
 
     MapApp.element(
-        app_title="PySepal Map App",
+        app_title=cm.app.title,
         app_icon="mdi-earth",
         main_map=[sepal_map],
         steps_data=[],
@@ -146,6 +149,9 @@ def MapAppDemo():
         right_panel_content=right_panel_content,
         right_panel_open=True,
         theme_state=theme_state,
+        # The picker offers these catalogs and writes the pick to the
+        # connection's LocaleState -- the same one use_translator reads.
+        locales=cm.available_locales(),
         dialog_width=750,
     )
 

--- a/demo_apps/solara_map_app/component/message/__init__.py
+++ b/demo_apps/solara_map_app/component/message/__init__.py
@@ -1,0 +1,29 @@
+"""Locale-aware translator for the demo app.
+
+The other templates build a module-level ``Translator`` at import time, which
+pins the app to one language for the life of the process. A Solara app has one
+locale per connection, so the translator has to be built per render instead:
+``use_locale`` reads the connection's resolved code and re-renders when the
+user picks a new language in the app bar.
+
+Accessed via ``from component.message import use_translator``.
+"""
+
+from pathlib import Path
+
+import solara
+
+from pysepal.solara import use_locale
+from pysepal.translator import Translator
+
+MESSAGE_DIR = Path(__file__).parent
+
+
+def use_translator() -> Translator:
+    """Return a Translator following this connection's resolved locale.
+
+    Returns:
+        A Translator rebuilt whenever the locale changes.
+    """
+    locale = use_locale()
+    return solara.use_memo(lambda: Translator(MESSAGE_DIR, target=locale), [locale])

--- a/demo_apps/solara_map_app/component/message/en/app.json
+++ b/demo_apps/solara_map_app/component/message/en/app.json
@@ -1,0 +1,26 @@
+{
+  "app": {
+    "title": "PySepal Map App"
+  },
+  "panel": {
+    "title": "Tools",
+    "description": "Select an area, process it, then inspect and export the results."
+  },
+  "section": {
+    "aoi": {
+      "title": "Select AOI"
+    },
+    "process": {
+      "title": "Process",
+      "description": "Derives two layers from the AOI and publishes a legend for each."
+    },
+    "layers": {
+      "title": "Layers",
+      "description": "Add a standalone demo layer or a PMTiles vector layer, or clear the map and its legends. Both show up in the layer control, top right."
+    },
+    "export": {
+      "title": "Export",
+      "description": "Send the AOI or a processed output to Earth Engine, Drive or SEPAL."
+    }
+  }
+}

--- a/demo_apps/solara_map_app/component/message/es/app.json
+++ b/demo_apps/solara_map_app/component/message/es/app.json
@@ -1,0 +1,26 @@
+{
+  "app": {
+    "title": "Aplicación de mapa PySepal"
+  },
+  "panel": {
+    "title": "Herramientas",
+    "description": "Seleccione un área, procésela y luego inspeccione y exporte los resultados."
+  },
+  "section": {
+    "aoi": {
+      "title": "Seleccionar AOI"
+    },
+    "process": {
+      "title": "Procesar",
+      "description": "Deriva dos capas del AOI y publica una leyenda para cada una."
+    },
+    "layers": {
+      "title": "Capas",
+      "description": "Añada una capa de demostración independiente o una capa vectorial PMTiles, o limpie el mapa y sus leyendas. Ambas aparecen en el control de capas, arriba a la derecha."
+    },
+    "export": {
+      "title": "Exportar",
+      "description": "Envíe el AOI o un resultado procesado a Earth Engine, Drive o SEPAL."
+    }
+  }
+}

--- a/demo_apps/solara_map_app/component/message/fr/app.json
+++ b/demo_apps/solara_map_app/component/message/fr/app.json
@@ -1,0 +1,26 @@
+{
+  "app": {
+    "title": "Application cartographique PySepal"
+  },
+  "panel": {
+    "title": "Outils",
+    "description": "Sélectionnez une zone, traitez-la, puis inspectez et exportez les résultats."
+  },
+  "section": {
+    "aoi": {
+      "title": "Sélectionner l'AOI"
+    },
+    "process": {
+      "title": "Traiter",
+      "description": "Dérive deux couches de l'AOI et publie une légende pour chacune."
+    },
+    "layers": {
+      "title": "Couches",
+      "description": "Ajoutez une couche de démonstration autonome ou une couche vectorielle PMTiles, ou effacez la carte et ses légendes. Les deux apparaissent dans le contrôle des couches, en haut à droite."
+    },
+    "export": {
+      "title": "Exporter",
+      "description": "Envoyez l'AOI ou un résultat traité vers Earth Engine, Drive ou SEPAL."
+    }
+  }
+}

--- a/demo_apps/solara_raster_app/app.py
+++ b/demo_apps/solara_raster_app/app.py
@@ -31,14 +31,28 @@ from pysepal.solara import (
     get_current_theme_state,
     setup_solara_server,
     setup_theme_colors,
+    use_locale,
 )
 from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
 from pysepal.solara.notifications import NotificationProvider, use_notifications
+from pysepal.translator import Translator
 
 setup_solara_server(extra_asset_locations=[])
 
 #: Points the demo at real class maps instead of the generated stand-in.
 RASTER_DIR_ENV_VAR = "PYSEPAL_DEMO_RASTER_DIR"
+
+#: Catalogs, but no importable package: ``gallery.py`` puts every demo directory
+#: on ``sys.path``, so a second demo shipping ``component/`` would resolve to
+#: whichever one imported first. The map app owns that name; this one stays flat.
+MESSAGE_DIR = Path(__file__).parent / "message"
+
+
+def use_translator() -> Translator:
+    """Return a Translator following this connection's resolved locale."""
+    locale = use_locale()
+    return solara.use_memo(lambda: Translator(MESSAGE_DIR, target=locale), [locale])
+
 
 # aa_test_congo holds these nine classes; codes 2 and 4 are the ones a continuous
 # ramp stretched over 2-34 renders as good as black.
@@ -129,6 +143,9 @@ def RasterPanel():
     # where the map app's session manager is active process-wide.
     theme_state = get_current_theme_state()
     notifications = use_notifications()
+    # Rebuilt on every locale change, so the closures below -- which use_task
+    # re-binds each render -- publish their toasts in the current language.
+    cm = use_translator()
 
     rasters = solara.use_memo(demo_rasters, [])
 
@@ -141,39 +158,39 @@ def RasterPanel():
 
     async def add_continuous():
         """What every raster looked like before class_colors: a stretched ramp."""
-        with notifications.track("Continuous colormap") as task:
-            task.step("preparing COG...")
+        with notifications.track(cm.tasks.continuous) as task:
+            task.step(cm.tasks.preparing)
             await sepal_map.add_raster_async(
                 rasters["congo"],
-                layer_name="Classes (continuous)",
+                layer_name=cm.layers.continuous,
                 key="continuous",
                 colormap="inferno",
             )
-        notifications.success("Continuous ramp added")
+        notifications.success(cm.toasts.continuous)
 
     async def add_class_colors():
         """The same raster, each class in its own color."""
-        with notifications.track("Class colors") as task:
-            task.step("preparing COG...")
+        with notifications.track(cm.tasks.classes) as task:
+            task.step(cm.tasks.preparing)
             await sepal_map.add_raster_async(
                 rasters["congo"],
-                layer_name="Classes (exact)",
+                layer_name=cm.layers.exact,
                 key="classes",
                 class_colors=CONGO_COLORS,
             )
-        notifications.success(f"{len(CONGO_COLORS)} classes added")
+        notifications.success(cm.toasts.classes.format(len(CONGO_COLORS)))
 
     async def add_large():
         """A raster with no overviews, which is the case ``optimize`` exists for."""
-        with notifications.track("Large raster") as task:
-            task.step("preparing COG with overviews...")
+        with notifications.track(cm.tasks.large) as task:
+            task.step(cm.tasks.preparing_overviews)
             await sepal_map.add_raster_async(
                 rasters["hansen"],
-                layer_name="Loss year",
+                layer_name=cm.layers.loss,
                 key="large",
                 class_colors=HANSEN_COLORS,
             )
-        notifications.success("Large raster added")
+        notifications.success(cm.toasts.large)
 
     continuous_task = solara.lab.use_task(
         add_continuous, dependencies=None, raise_error=False, prefer_threaded=False
@@ -191,7 +208,7 @@ def RasterPanel():
 
     def build_clear_button():
         """A plain ipyvuetify button, handed to MapApp intact with its handler."""
-        button = sw.Btn("clear rasters", small=True, block=True)
+        button = sw.Btn(cm.buttons.clear_rasters, small=True, block=True)
 
         def clear():
             for key in ("continuous", "classes", "large"):
@@ -200,46 +217,45 @@ def RasterPanel():
         button.on_event("click", lambda *args: clear())
         return button
 
-    clear_button = solara.use_memo(build_clear_button, [id(sepal_map)])
+    # Rebuilt on a language change too: it is a widget, not an element, so its
+    # label is set at construction and nothing re-renders it.
+    clear_button = solara.use_memo(build_clear_button, [id(sepal_map), cm.buttons.clear_rasters])
 
-    source = "generated stand-ins" if rasters["synthetic"] else "real class maps"
+    source = cm.source.synthetic if rasters["synthetic"] else cm.source.real
 
     MapApp.element(
-        app_title="Local rasters",
+        app_title=cm.app.title,
         app_icon="mdi-layers",
         main_map=[sepal_map],
         steps_data=[],
         right_panel_config={
-            "title": "Rasters",
+            "title": cm.panel.title,
             "icon": "mdi-image",
             "width": 380,
-            "description": "Each button renders a local raster through a different path.",
+            "description": cm.panel.description,
         },
         right_panel_content=[
             {
-                "title": "Local rasters",
+                "title": cm.section.title,
                 "icon": "mdi-image",
                 "content": [
                     TaskButtonComponent(
-                        label="continuous ramp", **continuous_props, small=True, block=True
+                        label=cm.buttons.continuous, **continuous_props, small=True, block=True
                     ),
                     TaskButtonComponent(
-                        label="class colors", **classes_props, small=True, block=True
+                        label=cm.buttons.classes, **classes_props, small=True, block=True
                     ),
                     TaskButtonComponent(
-                        label="large raster", **large_props, small=True, block=True
+                        label=cm.buttons.large, **large_props, small=True, block=True
                     ),
                     clear_button,
                 ],
-                "description": (
-                    f"Drawing {source}. A continuous ramp stretched across sparse class "
-                    f"codes renders them near-black; class_colors draws each one exactly. "
-                    f"Set {RASTER_DIR_ENV_VAR} to use real products."
-                ),
+                "description": cm.section.description.format(source, RASTER_DIR_ENV_VAR),
             }
         ],
         right_panel_open=True,
         theme_state=theme_state,
+        locales=cm.available_locales(),
         dialog_width=750,
     )
 

--- a/demo_apps/solara_raster_app/message/en/app.json
+++ b/demo_apps/solara_raster_app/message/en/app.json
@@ -1,0 +1,40 @@
+{
+  "app": {
+    "title": "Local rasters"
+  },
+  "panel": {
+    "title": "Rasters",
+    "description": "Each button renders a local raster through a different path."
+  },
+  "section": {
+    "title": "Local rasters",
+    "description": "Drawing {}. A continuous ramp stretched across sparse class codes renders them near-black; class_colors draws each one exactly. Set {} to use real products."
+  },
+  "source": {
+    "synthetic": "generated stand-ins",
+    "real": "real class maps"
+  },
+  "buttons": {
+    "continuous": "continuous ramp",
+    "classes": "class colors",
+    "large": "large raster",
+    "clear_rasters": "clear rasters"
+  },
+  "layers": {
+    "continuous": "Classes (continuous)",
+    "exact": "Classes (exact)",
+    "loss": "Loss year"
+  },
+  "tasks": {
+    "continuous": "Continuous colormap",
+    "classes": "Class colors",
+    "large": "Large raster",
+    "preparing": "preparing COG...",
+    "preparing_overviews": "preparing COG with overviews..."
+  },
+  "toasts": {
+    "continuous": "Continuous ramp added",
+    "classes": "{} classes added",
+    "large": "Large raster added"
+  }
+}

--- a/demo_apps/solara_raster_app/message/es/app.json
+++ b/demo_apps/solara_raster_app/message/es/app.json
@@ -1,0 +1,40 @@
+{
+  "app": {
+    "title": "Rásteres locales"
+  },
+  "panel": {
+    "title": "Rásteres",
+    "description": "Cada botón dibuja un ráster local por una vía distinta."
+  },
+  "section": {
+    "title": "Rásteres locales",
+    "description": "Dibujando {}. Una rampa continua estirada sobre códigos de clase dispersos los muestra casi negros; class_colors dibuja cada uno con su color exacto. Defina {} para usar productos reales."
+  },
+  "source": {
+    "synthetic": "sustitutos generados",
+    "real": "mapas de clases reales"
+  },
+  "buttons": {
+    "continuous": "rampa continua",
+    "classes": "colores por clase",
+    "large": "ráster grande",
+    "clear_rasters": "limpiar rásteres"
+  },
+  "layers": {
+    "continuous": "Clases (continuo)",
+    "exact": "Clases (exacto)",
+    "loss": "Año de pérdida"
+  },
+  "tasks": {
+    "continuous": "Mapa de color continuo",
+    "classes": "Colores por clase",
+    "large": "Ráster grande",
+    "preparing": "preparando COG...",
+    "preparing_overviews": "preparando COG con vistas generales..."
+  },
+  "toasts": {
+    "continuous": "Rampa continua añadida",
+    "classes": "{} clases añadidas",
+    "large": "Ráster grande añadido"
+  }
+}

--- a/demo_apps/solara_raster_app/message/fr/app.json
+++ b/demo_apps/solara_raster_app/message/fr/app.json
@@ -1,0 +1,40 @@
+{
+  "app": {
+    "title": "Rasters locaux"
+  },
+  "panel": {
+    "title": "Rasters",
+    "description": "Chaque bouton affiche un raster local par un chemin différent."
+  },
+  "section": {
+    "title": "Rasters locaux",
+    "description": "Affichage de {}. Une rampe continue étirée sur des codes de classe épars les rend presque noirs ; class_colors dessine chacun avec sa couleur exacte. Définissez {} pour utiliser de vrais produits."
+  },
+  "source": {
+    "synthetic": "substituts générés",
+    "real": "vraies cartes de classes"
+  },
+  "buttons": {
+    "continuous": "rampe continue",
+    "classes": "couleurs par classe",
+    "large": "raster volumineux",
+    "clear_rasters": "effacer les rasters"
+  },
+  "layers": {
+    "continuous": "Classes (continu)",
+    "exact": "Classes (exact)",
+    "loss": "Année de perte"
+  },
+  "tasks": {
+    "continuous": "Palette continue",
+    "classes": "Couleurs par classe",
+    "large": "Raster volumineux",
+    "preparing": "préparation du COG...",
+    "preparing_overviews": "préparation du COG avec aperçus..."
+  },
+  "toasts": {
+    "continuous": "Rampe continue ajoutée",
+    "classes": "{} classes ajoutées",
+    "large": "Raster volumineux ajouté"
+  }
+}

--- a/docs/guides/migration-v4.md
+++ b/docs/guides/migration-v4.md
@@ -134,9 +134,9 @@ use the `.files.*` API need no change.
 
 ## 6. `~/.sepal-ui-config` and its CLI tools are gone
 
-The file is deleted along with every reader and writer. Theme and locale no
-longer persist anywhere: they are per-runtime state now, because a machine-global
-file is shared by every connection in a multi-user container.
+The file is deleted along with every reader and writer. Theme and locale are
+per-runtime state now, resolved and persisted in the browser, because a
+machine-global file is shared by every connection in a multi-user container.
 
 Removed: `pysepal.conf`, `pysepal.config`, `pysepal.config_file`,
 `pysepal.frontend.styles.get_theme`, and `set_config`, `set_config_locale`,
@@ -167,6 +167,35 @@ ms = Translator(json_folder)
 # 4.0 — pass the target you want
 ms = Translator(json_folder, target=user_locale)
 ```
+
+Where `user_locale` comes from is the other half. `LocaleSelect` resolves it in
+the browser — `localStorage[":sepalUi:locale"]`, then `navigator.language`, then
+English, each candidate matched against the catalogs the app actually ships —
+and pushes the result into a scope-keyed `LocaleState`. Build the translator
+from that and a language change re-renders in place, with no reload:
+
+```python
+from pysepal.solara import use_locale
+
+@solara.component
+def Page():
+    locale = use_locale()
+    ms = solara.use_memo(lambda: Translator(json_folder, target=locale), [locale])
+
+    MapApp.element(app_title=ms.app.title, locales=ms.available_locales())
+```
+
+`MapApp` takes locale _codes_ rather than a `Translator` because `Translator`
+subclasses `dict`, which reacton flattens on the way to `.element()`. Outside a
+Solara render, `get_current_locale_state()` returns the same state directly.
+
+A 3.x locale saved in `~/.sepal-ui-config` is not migrated: the file is read
+nowhere in 4.0, so the first load falls to `navigator.language`.
+
+The picker now offers every catalog the app ships. Previously the offered list
+was intersected with `pysepal/data/locale.parquet`, which has `es-ES` but no
+bare `es` — so pysepal's own bundled `message/es/` and `message/ru-RU/` could
+never be selected. The parquet now supplies only display names and flags.
 
 **CLI**: the `module_theme` and `module_l10n` entry points are removed — both
 existed only to edit that file. The remaining console scripts are
@@ -326,8 +355,10 @@ that forgot the decorator fails loudly instead of serving the wrong identity.
       four legacy verbs with `client.files.*`.
 - [ ] Create the results directory yourself before writing into `results_path`;
       `SepalClient.create()` no longer does it, and nothing fails until the write.
-- [ ] Remove every `~/.sepal-ui-config` reader/writer; pass `target=` to
-      `Translator` and use `get_current_theme_state()` for theme.
+- [ ] Remove every `~/.sepal-ui-config` reader/writer; build the `Translator`
+      from `use_locale()` and use `get_current_theme_state()` for theme.
+- [ ] Replace any "refresh to apply the language" instruction in your UI;
+      switching is live, and picks no longer survive as a machine-global file.
 - [ ] Drop `module_theme` / `module_l10n` from scripts and CI.
 - [ ] Rename `SOLARA_TEST` to `PYSEPAL_DEV_AUTH` in `.env`, compose files and
       deployment manifests.

--- a/docs/guides/solara-mapapp-component.md
+++ b/docs/guides/solara-mapapp-component.md
@@ -2,7 +2,7 @@
 
 `MapAppComponent` is a first-class Solara component that replaces the
 legacy `MapApp(v.VuetifyTemplate)`. It is usable with `with` syntax,
-exposes typed dataclass props, auto-wires `ThemeState` / `Translator`,
+exposes typed dataclass props, auto-wires `ThemeState` / `LocaleState`,
 and preserves the visual design of the original `MapApp.vue`
 (drawer, narrow-mode bottom sheet, dialog steps, right panel).
 
@@ -76,25 +76,25 @@ def Page():
 
 ## Typed props
 
-| Prop                    | Type                              | Purpose                                       |
-| ----------------------- | --------------------------------- | --------------------------------------------- |
-| `app_title`             | `str`                             | Drawer header text.                           |
-| `app_icon`              | `str`                             | Drawer header MDI icon.                       |
-| `sepal_map`             | `Optional[Widget]`                | Map widget rendered in the main area.         |
-| `steps`                 | `Sequence[StepConfig]`            | Left-drawer step entries.                     |
-| `right_panel_config`    | `Optional[RightPanelConfig]`      | Display config for the right panel chrome.    |
-| `right_panel_content`   | `Sequence[PanelSection]`          | Section list rendered inside the right panel. |
-| `right_panel_open`      | `bool` or `solara.Reactive[bool]` | Controlled open/close state.                  |
-| `current_step`          | `Optional[int]` reactive          | Controlled active step id.                    |
-| `initial_step`          | `Optional[int]`                   | Step auto-activated on first mount.           |
-| `theme_state`           | `Optional[ThemeState]`            | Defaults to `get_current_theme_state()`.      |
-| `translator`            | `Optional[Translator]`            | Drives the locale selector when provided.     |
-| `external_links`        | `Sequence[ExternalLink]`          | Drawer footer link tiles.                     |
-| `repo_url` / `docs_url` | `str`                             | Auto-derived Source / Docs / Bug links.       |
-| `dialog_width`          | `int`                             | Default width for `display="dialog"` steps.   |
-| `dialog_fullscreen`     | `bool`                            | Force dialog steps to render full-screen.     |
-| `on_step_action`        | `Callable[[int, str], None]`      | Fires when a dialog footer button is clicked. |
-| `on_right_panel_toggle` | `Callable[[bool], None]`          | Fires when the right panel opens/closes.      |
+| Prop                    | Type                              | Purpose                                                                                             |
+| ----------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `app_title`             | `str`                             | Drawer header text.                                                                                 |
+| `app_icon`              | `str`                             | Drawer header MDI icon.                                                                             |
+| `sepal_map`             | `Optional[Widget]`                | Map widget rendered in the main area.                                                               |
+| `steps`                 | `Sequence[StepConfig]`            | Left-drawer step entries.                                                                           |
+| `right_panel_config`    | `Optional[RightPanelConfig]`      | Display config for the right panel chrome.                                                          |
+| `right_panel_content`   | `Sequence[PanelSection]`          | Section list rendered inside the right panel.                                                       |
+| `right_panel_open`      | `bool` or `solara.Reactive[bool]` | Controlled open/close state.                                                                        |
+| `current_step`          | `Optional[int]` reactive          | Controlled active step id.                                                                          |
+| `initial_step`          | `Optional[int]`                   | Step auto-activated on first mount.                                                                 |
+| `theme_state`           | `Optional[ThemeState]`            | Defaults to `get_current_theme_state()`.                                                            |
+| `locales`               | `Optional[Iterable[str]]`         | Codes the locale selector offers. Not a `Translator`: it subclasses `dict`, which reacton flattens. |
+| `external_links`        | `Sequence[ExternalLink]`          | Drawer footer link tiles.                                                                           |
+| `repo_url` / `docs_url` | `str`                             | Auto-derived Source / Docs / Bug links.                                                             |
+| `dialog_width`          | `int`                             | Default width for `display="dialog"` steps.                                                         |
+| `dialog_fullscreen`     | `bool`                            | Force dialog steps to render full-screen.                                                           |
+| `on_step_action`        | `Callable[[int, str], None]`      | Fires when a dialog footer button is clicked.                                                       |
+| `on_right_panel_toggle` | `Callable[[bool], None]`          | Fires when the right panel opens/closes.                                                            |
 
 ### `StepConfig.content` is a Solara render function
 
@@ -137,7 +137,7 @@ panel visibility.
 | `right_panel_content=[{"title": ..., "content": [W]}]`   | `right_panel_content=[PanelSection(title=..., content=fn)]`                            |
 | Eager widget construction                                | `content=` is a Solara render function (lazy)                                          |
 | Manual `theme_toggle=ThemeToggle(...)` wiring            | Auto: pass `theme_state=` (or omit; falls back to `get_current_theme_state()`)         |
-| Manual `language_selector=LocaleSelect(translator=...)`  | Auto: pass `translator=` (or omit)                                                     |
+| Manual `language_selector=LocaleSelect(translator=...)`  | Auto: pass `locales=ms.available_locales()` (or omit)                                  |
 | `model=HasTraits()` auto-link                            | Use `solara.Reactive` props (`current_step=`, `right_panel_open=`)                     |
 
 ## Notifications

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,8 @@ ignore-path-errors = ["docs/source/index.rst;D000"]
 using = "PEP631:test;dev;doc"
 
 [tool.codespell]
-skip = 'CHANGELOG.md,pysepal/message/**/*.json,pysepal/data/gaul_iso.json'
+# Translation catalogs are not English, so its dictionary does not apply.
+skip = 'CHANGELOG.md,pysepal/message/**/*.json,demo_apps/**/message/**/*.json,pysepal/data/gaul_iso.json'
 
 [tool.black]
 line-length = 100

--- a/pysepal/sepalwidgets/app.py
+++ b/pysepal/sepalwidgets/app.py
@@ -11,6 +11,7 @@ Example:
         sw.LocaleSelect()
 """
 
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -42,6 +43,7 @@ from pysepal.sepalwidgets.alert import Banner
 from pysepal.sepalwidgets.sepalwidget import SepalWidget
 from pysepal.sepalwidgets.vue_app import ThemeToggle
 from pysepal.sepalwidgets.widget import Markdown
+from pysepal.solara.locale import describe_offered_locales
 from pysepal.translator import Translator
 
 logger = logging.getLogger("sepalui.app")
@@ -91,7 +93,6 @@ class LocaleSelect(v.Menu, SepalWidget):
         # extract the language information from the translator
         # if not set default to english
         code = "en" if translator is None else translator._target
-        loc = self.COUNTRIES[self.COUNTRIES.code == code].squeeze()
 
         self.locale_icon = v.Icon(class_="mr-2", children=["mdi-translate"])
 
@@ -120,7 +121,7 @@ class LocaleSelect(v.Menu, SepalWidget):
             v_model=False,
             close_on_content_click=True,
             v_slots=[{"name": "activator", "variable": "x", "children": self.btn}],
-            value=loc.code,
+            value=code,
         )
 
         # add js behaviour
@@ -139,14 +140,16 @@ class LocaleSelect(v.Menu, SepalWidget):
             the list of country widget to display in the app
         """
         country_list = []
-        filtered_countries = self.COUNTRIES[self.COUNTRIES.code.isin(locales)]
-        for r in filtered_countries.itertuples(index=False):
+        catalog = json.loads(self.COUNTRIES.to_json(orient="records"))
+        for record in describe_offered_locales(locales, catalog):
             children = [
-                v.ListItemContent(class_="mr-2", children=[v.ListItemTitle(children=[r.name])]),
-                v.ListItemActionText(children=[r.code]),
+                v.ListItemContent(
+                    class_="mr-2", children=[v.ListItemTitle(children=[record["name"]])]
+                ),
+                v.ListItemActionText(children=[record["code"]]),
             ]
 
-            country_list.append(v.ListItem(value=r.code, children=children))
+            country_list.append(v.ListItem(value=record["code"], children=children))
 
         return country_list
 
@@ -158,10 +161,7 @@ class LocaleSelect(v.Menu, SepalWidget):
         if not change["new"]:
             return
 
-        # get the line in the locale dataframe
-        loc = self.COUNTRIES[self.COUNTRIES.code == change["new"]].squeeze()
-
-        self.btn.children = [self.locale_icon, loc.code]
+        self.btn.children = [self.locale_icon, change["new"]]
         # self.btn.color = "info"
 
         return

--- a/pysepal/sepalwidgets/vue/LocaleSelect.vue
+++ b/pysepal/sepalwidgets/vue/LocaleSelect.vue
@@ -60,7 +60,11 @@
 //
 // matchOffered is a transcription of pysepal.solara.locale.match_offered_locale
 // (the tested Python reference implementation) -- keep both in sync.
-const STORAGE_KEY = ":sepalUi:locale"; // plain string, not JSON
+//
+// The storage key is written out at each use rather than hoisted into a const:
+// ipyvue evaluates the object below, not this file as a module, so a binding
+// declared out here is undefined inside methods. Theming.vue inlines its key
+// for the same reason. tests/test_sepalwidgets/test_vue_templates.py guards it.
 
 export default {
   name: "LocaleSelect",
@@ -136,17 +140,21 @@ export default {
       return offered.find((code) => code.split("-")[0] === primary) || "";
     },
     storageGet() {
+      // Never swallow silently: these catches are for a blocked-storage
+      // SecurityError, and an empty one hid a ReferenceError that stopped
+      // every pick from persisting.
       try {
-        return localStorage.getItem(STORAGE_KEY) || "";
+        return localStorage.getItem(":sepalUi:locale") || "";
       } catch (e) {
-        return ""; // storage unavailable (e.g. blocked in iframe): degrade
+        console.warn("[pysepal] cannot read the stored locale:", e);
+        return "";
       }
     },
     storageSet(code) {
       try {
-        localStorage.setItem(STORAGE_KEY, code);
+        localStorage.setItem(":sepalUi:locale", code);
       } catch (e) {
-        // storage unavailable: the pick still applies for this session
+        console.warn("[pysepal] cannot persist the locale:", e);
       }
     },
     localeResolved() {

--- a/pysepal/sepalwidgets/vue/LocaleSelect.vue
+++ b/pysepal/sepalwidgets/vue/LocaleSelect.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <!-- Main language selector button -->
     <v-btn
       depressed
       @click="openDialog"
@@ -10,7 +9,6 @@
       {{ currentLanguage }}
     </v-btn>
 
-    <!-- Dialog with language options -->
     <v-dialog v-model="dialogOpen" max-width="400">
       <v-card>
         <v-card-title class="headline d-flex justify-space-between">
@@ -19,18 +17,6 @@
             <v-icon>mdi-close</v-icon>
           </v-btn>
         </v-card-title>
-        <v-divider></v-divider>
-        <v-card-text>
-          <v-alert
-            type="info"
-            border="left"
-            colored-border
-            icon="mdi-alert"
-            class="mt-4"
-            >To apply the language settings, you need to refresh the
-            page.</v-alert
-          >
-        </v-card-text>
         <v-divider></v-divider>
         <v-card-text>
           <v-list>
@@ -44,8 +30,7 @@
                   >{{ locale.name }} ({{ locale.code }})</v-list-item-title
                 >
               </v-list-item-content>
-
-              <v-list-item-action v-if="locale.code === selectedLanguage">
+              <v-list-item-action v-if="locale.code === currentLanguage">
                 <v-icon color="primary">mdi-check</v-icon>
               </v-list-item-action>
             </v-list-item>
@@ -57,8 +42,28 @@
 </template>
 
 <script>
+// Browser-owned locale resolution, mirroring Theming.vue's ownership model.
+//
+// Resolution order on mount (each candidate validated via matchOffered):
+//   1. localStorage[":sepalUi:locale"]  -- a previous explicit pick
+//   2. navigator.language               -- browser auto-detection
+//   3. "en"
+//
+// The ladder runs only ONCE per tab: after it has resolved, remounts adopt the
+// value Python already holds (see mounted()).
+//
+// The result is pushed to Python by DIRECT trait assignment
+// (this.selected_locale = code). Never use $emit("update:selected_locale"):
+// that is the Vue .sync convention, which requires a binding parent and is
+// silently dropped when this widget is a root widget -- which is why picks
+// did not survive a refresh before pysepal 4.
+//
+// matchOffered is a transcription of pysepal.solara.locale.match_offered_locale
+// (the tested Python reference implementation) -- keep both in sync.
+const STORAGE_KEY = ":sepalUi:locale"; // plain string, not JSON
+
 export default {
-  name: "LanguageSelector",
+  name: "LocaleSelect",
 
   props: {
     available_locales: {
@@ -66,91 +71,113 @@ export default {
       required: true,
       default: () => [{ code: "en", name: "English", flag: "gb" }],
     },
-    selected_locale: {
-      type: String,
-      required: true,
-      default: "en",
-    },
+    selected_locale: { type: String, required: true, default: "en" },
   },
 
   data() {
+    // ipyvue calls this script's data() unbound, so `this` is the exported
+    // options object -- never the component instance. Initialisers must be
+    // literals (see Theming.vue); mounted() sets the real value.
     return {
       dialogOpen: false,
-      selectedLanguage: this.selected_locale,
-      currentLanguage: this.selected_locale,
+      currentLanguage: "",
     };
   },
 
   watch: {
     selected_locale(newValue) {
       this.currentLanguage = newValue;
-      this.selectedLanguage = newValue;
-    },
-
-    available_locales: {
-      immediate: true,
-      handler(newCountries) {
-        // If there's only one language available, set it as the current language
-        if (newCountries.length === 1) {
-          const onlyLanguage = newCountries[0].code;
-
-          if (this.currentLanguage !== onlyLanguage) {
-            this.currentLanguage = onlyLanguage;
-            this.selectedLanguage = onlyLanguage;
-            this.$emit("update:selected_locale", onlyLanguage);
-            this.$emit("language-changed", onlyLanguage);
-          }
-        }
-      },
     },
   },
 
-  mounted() {
-    // Check if the selected locale exists in available locales
-    const localeExists = this.available_locales.some(
-      (country) => country.code === this.selected_locale
-    );
-
-    if (localeExists) {
-      // If locale exists, update current and selected language
-      this.currentLanguage = this.selected_locale;
-      this.selectedLanguage = this.selected_locale;
-    } else if (this.available_locales.length > 0) {
-      // If locale doesn't exist but we have available locales, use the first one
-      this.currentLanguage = this.available_locales[0].code;
-      this.selectedLanguage = this.available_locales[0].code;
-      // Emit events to update parent component
-      this.$emit("update:selected_locale", this.available_locales[0].code);
-      this.$emit("language-changed", this.available_locales[0].code);
-    } else {
-      // Fallback to 'en' if no locales available
-      const fallbackLocale = "en";
-      this.currentLanguage = fallbackLocale;
-      this.selectedLanguage = fallbackLocale;
-      this.$emit("update:selected_locale", fallbackLocale);
-      this.$emit("language-changed", fallbackLocale);
+  created() {
+    if (!window.sepalUi) {
+      window.sepalUi = {};
     }
   },
 
+  mounted() {
+    const offered = this.offeredCodes();
+    // MapApp.vue destroys and recreates this widget on every drawer
+    // expand/collapse, so mounted() runs many times per page. Once the ladder
+    // has resolved a locale for this tab, Python owns the value: re-running
+    // the ladder would revert a live pick (and, with two tabs sharing one
+    // localStorage, adopt the *other* tab's pick). Same ownership handoff as
+    // Theming.vue.
+    if (
+      this.localeResolved() &&
+      this.selected_locale &&
+      offered.includes(this.selected_locale)
+    ) {
+      this.apply(this.selected_locale);
+      return;
+    }
+    const stored = this.matchOffered(this.storageGet(), offered);
+    if (stored) {
+      this.apply(stored);
+      return;
+    }
+    const nav = this.matchOffered(
+      (typeof navigator !== "undefined" && navigator.language) || "",
+      offered
+    );
+    this.apply(nav || (offered.includes("en") ? "en" : offered[0] || "en"));
+  },
+
   methods: {
+    offeredCodes() {
+      return (this.available_locales || []).map((locale) => locale.code);
+    },
+    matchOffered(candidate, offered) {
+      if (!candidate) return "";
+      if (offered.includes(candidate)) return candidate;
+      const primary = candidate.split("-")[0];
+      if (offered.includes(primary)) return primary;
+      return offered.find((code) => code.split("-")[0] === primary) || "";
+    },
+    storageGet() {
+      try {
+        return localStorage.getItem(STORAGE_KEY) || "";
+      } catch (e) {
+        return ""; // storage unavailable (e.g. blocked in iframe): degrade
+      }
+    },
+    storageSet(code) {
+      try {
+        localStorage.setItem(STORAGE_KEY, code);
+      } catch (e) {
+        // storage unavailable: the pick still applies for this session
+      }
+    },
+    localeResolved() {
+      // Per-tab (not per-widget) marker: survives widget destruction, resets
+      // on a real page load so browser auto-detection stays live.
+      return !!(window.sepalUi && window.sepalUi.localeResolved);
+    },
+    markLocaleResolved() {
+      if (window.sepalUi) {
+        window.sepalUi.localeResolved = true;
+      }
+    },
+    apply(code) {
+      this.markLocaleResolved();
+      this.currentLanguage = code;
+      if (this.selected_locale !== code) {
+        // eslint-disable-next-line vue/no-mutating-props
+        this.selected_locale = code;
+      }
+    },
     openDialog() {
-      this.selectedLanguage = this.currentLanguage;
       this.dialogOpen = true;
     },
-
     closeDialog() {
       this.dialogOpen = false;
     },
     selectLanguage(code) {
-      this.selectedLanguage = code;
-      if (this.selectedLanguage !== this.currentLanguage) {
-        this.currentLanguage = this.selectedLanguage;
-
-        // Emit events for parent component
-        this.$emit("update:selected_locale", this.selectedLanguage);
-        this.$emit("language-changed", this.selectedLanguage);
+      if (code !== this.currentLanguage) {
+        this.storageSet(code);
+        this.apply(code);
       }
-
       this.dialogOpen = false;
     },
   },

--- a/pysepal/sepalwidgets/vue_app.py
+++ b/pysepal/sepalwidgets/vue_app.py
@@ -189,6 +189,7 @@ class MapApp(v.VuetifyTemplate):
             ],
         )
         self.observe(self._sync_map_theme_state, ["theme_toggle", "main_map"])
+        self.observe(self._sync_right_panel, ["right_panel_config", "right_panel_content"])
         self._sync_map_insets()
         self._sync_map_theme_state()
 
@@ -403,6 +404,22 @@ class MapApp(v.VuetifyTemplate):
         new_config = change["new"]
         if "width" in new_config:
             self.right_panel_width = new_config["width"]
+
+    def _sync_right_panel(self, *args):
+        """Mirror panel config and content onto the child widget that renders them.
+
+        ``RightPanel`` is built once in ``__init__`` from the values passed
+        then, and it -- not ``MapApp`` -- is what the panel renders from. Without
+        this the sibling observers only run child -> parent, so a re-render
+        updated these traits and the panel kept showing the strings it was born
+        with. It does not recurse: ``_on_right_panel_config_change`` writes
+        ``right_panel_width``, never ``right_panel_config``.
+        """
+        if not self.right_panel:
+            return
+        panel = self.right_panel[0]
+        panel.config = self.right_panel_config
+        panel.content_data = self.right_panel_content
 
 
 class ThemeToggle(v.VuetifyTemplate):

--- a/pysepal/sepalwidgets/vue_app.py
+++ b/pysepal/sepalwidgets/vue_app.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 import ipyvuetify as v
 import pandas as pd
@@ -11,6 +11,11 @@ from ipywidgets import DOMWidget, jsdlink, link
 from ipywidgets.widgets.widget import widget_serialization
 from traitlets import Bool, Dict, HasTraits, Instance, Int, List, Unicode, observe
 
+from pysepal.solara.locale import (
+    LocaleState,
+    describe_offered_locales,
+    resolve_locale_state,
+)
 from pysepal.solara.theme import ThemeState, get_current_theme_state
 from pysepal.translator import Translator
 
@@ -96,6 +101,8 @@ class MapApp(v.VuetifyTemplate):
         self,
         theme_toggle: "ThemeToggle" = None,
         theme_state: Optional[ThemeState] = None,
+        locale_state: Optional[LocaleState] = None,
+        locales: Optional[Iterable[str]] = None,
         initial_step: Optional[int] = None,
         model: Optional[HasTraits] = None,
         **kwargs,
@@ -106,6 +113,16 @@ class MapApp(v.VuetifyTemplate):
         ----------
         theme_toggle : ThemeToggle, optional
             Theme toggle widget
+        theme_state : ThemeState, optional
+            Shared theme state; defaults to the current scope's.
+        locale_state : LocaleState, optional
+            Shared locale state; defaults to the current scope's.
+        locales : iterable of str, optional
+            Locale codes the default ``LocaleSelect`` offers, normally
+            ``translator.available_locales()``. Codes rather than a
+            ``Translator`` because ``Translator`` subclasses ``dict``, and
+            reacton passes a plain dict through to ``MapApp.element``.
+            Ignored when a ``language_selector`` is supplied.
         initial_step : int, optional
             Initial step to display
         model : HasTraits, optional
@@ -114,6 +131,8 @@ class MapApp(v.VuetifyTemplate):
             Additional parameters
         """
         self._theme_state = theme_state or get_current_theme_state()
+        self._locale_state = resolve_locale_state(locale_state)
+        self._locales = locales
         self._model = model
         self._model_links = []  # Store links for cleanup
         kwargs["theme_toggle"] = self._coerce_theme_toggle(theme_toggle, self._theme_state)
@@ -137,7 +156,9 @@ class MapApp(v.VuetifyTemplate):
             kwargs["right_panel_open"] = right_panel.is_open
             kwargs["right_panel_width"] = right_panel.config.get("width", 300)
 
-        kwargs["language_selector"] = kwargs.get("language_selector", [LocaleSelect()])
+        kwargs["language_selector"] = self._coerce_locale_select(
+            kwargs.get("language_selector"), self._locale_state
+        )
 
         # Handle initial step configuration
         if initial_step is not None:
@@ -191,6 +212,25 @@ class MapApp(v.VuetifyTemplate):
             return widgets
 
         return [ThemeToggle(theme_state=theme_state)]
+
+    def _coerce_locale_select(
+        self, language_selector, locale_state: Optional[LocaleState]
+    ) -> list["LocaleSelect"]:
+        """Normalize language selector input and bind it to the given locale state."""
+        if isinstance(language_selector, (list, tuple)):
+            widgets = list(language_selector)
+        elif language_selector is None:
+            widgets = []
+        else:
+            widgets = [language_selector]
+
+        if widgets:
+            widget = widgets[0]
+            if hasattr(widget, "bind_locale_state"):
+                widget.bind_locale_state(locale_state)
+            return widgets
+
+        return [LocaleSelect(locales=self._locales, locale_state=locale_state)]
 
     # Mirror of MapApp.vue: viewports below this width dock the right
     # panel as a bottom sheet sized at NARROW_PANEL_HEIGHT_VH of the
@@ -480,22 +520,72 @@ class LocaleSelect(v.VuetifyTemplate):
     selected_locale = Unicode("en").tag(sync=True)
     value = Unicode().tag(sync=True)
 
-    def __init__(self, translator: Optional[Translator] = None, **kwargs):
-        """Instantiate the LocaleSelect class."""
+    def __init__(
+        self,
+        translator: Optional[Translator] = None,
+        locales: Optional[Iterable[str]] = None,
+        locale_state: Optional[LocaleState] = None,
+        **kwargs,
+    ):
+        """Instantiate the LocaleSelect class.
+
+        The effective locale is resolved in the browser (localStorage ->
+        ``navigator.language`` -> "en") and pushed back through
+        ``selected_locale``; this class only mirrors the resolved value into
+        the bound :class:`~pysepal.solara.locale.LocaleState`.
+
+        Args:
+            translator: Translator whose catalogs become the offered languages.
+            locales: Offered locale codes, taking precedence over ``translator``.
+            locale_state: Shared state to mirror the resolved locale into.
+            kwargs: any argument for a VuetifyTemplate object.
+        """
+        self._locale_state: Optional[LocaleState] = None
         super().__init__(**kwargs)
 
-        available_locales = ["en"] if translator is None else translator.available_locales()
-        available_locales = self.COUNTRIES[self.COUNTRIES.code.isin(available_locales)]
-        self.available_locales = json.loads(available_locales.to_json(orient="records"))
+        if locales is not None:
+            offered = list(locales)
+        else:
+            offered = ["en"] if translator is None else translator.available_locales()
+        self.available_locales = describe_offered_locales(
+            offered, json.loads(self.COUNTRIES.to_json(orient="records"))
+        )
 
         # TODO: consider removing this, I'm not sure if an app is using the value
         jsdlink((self, "selected_locale"), (self, "value"))
 
         self.observe(self._on_locale_select, "selected_locale")
 
-    def _on_locale_select(self, change: dict) -> None:
-        """adapt the application to the newly selected language."""
-        if not change["new"]:
+        if locale_state is not None:
+            self.bind_locale_state(locale_state)
+
+    def bind_locale_state(self, locale_state: Optional[LocaleState]) -> None:
+        """Bind the widget to a shared locale state."""
+        if locale_state is self._locale_state:
             return
 
-        return
+        if self._locale_state is not None:
+            self._locale_state.unobserve(self._on_locale_state_change, "locale")
+
+        self._locale_state = locale_state
+        if self._locale_state is None:
+            return
+
+        self.selected_locale = self._locale_state.locale
+        self._locale_state.observe(self._on_locale_state_change, "locale")
+
+    def get_locale_state(self) -> Optional[LocaleState]:
+        """Return the currently bound locale state."""
+        return self._locale_state
+
+    def _on_locale_select(self, change: dict) -> None:
+        """Mirror the browser-resolved locale into the shared locale state."""
+        if not change["new"]:
+            return
+        if self._locale_state is not None:
+            self._locale_state.set_locale(change["new"])
+
+    def _on_locale_state_change(self, change: dict) -> None:
+        """Mirror external locale state changes back into the widget."""
+        if change["new"] and change["new"] != self.selected_locale:
+            self.selected_locale = change["new"]

--- a/pysepal/solara/__init__.py
+++ b/pysepal/solara/__init__.py
@@ -13,6 +13,12 @@ from .errors import (
     SepalSessionError,
     SessionScopeClosedError,
 )
+from .locale import (
+    LocaleState,
+    get_current_locale_state,
+    resolve_locale_state,
+    use_locale,
+)
 from .notifications import (
     NotificationProvider,
     notify,
@@ -44,6 +50,7 @@ from .utils import (
 )
 
 __all__ = [
+    "LocaleState",
     "MissingSepalHeadersError",
     "NotificationProvider",
     "PROCESS_SCOPE",
@@ -58,6 +65,7 @@ __all__ = [
     "current_scope_id",
     "get_current_drive_interface",
     "get_current_gee_interface",
+    "get_current_locale_state",
     "get_current_sepal_client",
     "get_current_session_info",
     "get_current_theme_state",
@@ -66,12 +74,14 @@ __all__ = [
     "has_scoped_state",
     "notify",
     "prime_dev_auth",
+    "resolve_locale_state",
     "resolve_scope_id",
     "resolve_theme_state",
     "setup_sessions",
     "setup_solara_server",
     "setup_theme_colors",
     "track_task",
+    "use_locale",
     "use_notifications",
     "use_theme_dark",
     "with_sepal_sessions",

--- a/pysepal/solara/locale.py
+++ b/pysepal/solara/locale.py
@@ -1,0 +1,135 @@
+"""Scope-keyed locale state and Solara hooks."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+import solara
+from traitlets import HasTraits, Unicode
+
+from pysepal.solara.ui_state import get_scoped_state
+
+
+def match_offered_locale(candidate: str, offered: Iterable[str]) -> str:
+    """Return the code from ``offered`` that best matches ``candidate``.
+
+    Order: exact match, bare primary subtag if offered, then the first offered
+    variant sharing the primary subtag. ``navigator.language`` reports
+    ``es-CL`` where an app ships ``es``, and a catalog may ship ``pt-BR``
+    where the browser reports ``pt``; both must resolve rather than fall
+    through to English.
+
+    Args:
+        candidate: The code to match, in IETF BCP 47.
+        offered: The codes to match against, in preference order.
+
+    Returns:
+        The matching code, or ``""`` so callers can try their next source.
+    """
+    if not candidate:
+        return ""
+    offered = list(offered)
+    if candidate in offered:
+        return candidate
+    primary = candidate.split("-")[0]
+    if primary in offered:
+        return primary
+    return next((code for code in offered if code.split("-")[0] == primary), "")
+
+
+def describe_offered_locales(
+    offered: Iterable[str], catalog: Iterable[Dict[str, str]]
+) -> List[Dict[str, str]]:
+    """Pair each offered locale code with a display name and flag.
+
+    ``offered`` comes from the app's message folders and is authoritative:
+    every code is returned, because a catalog the app ships must be
+    selectable. ``catalog`` only supplies presentation, matched through
+    :func:`match_offered_locale`, so a bare ``es`` borrows the name and flag
+    of ``es-ES`` while keeping ``es`` as its value -- the value is a folder
+    name that :class:`~pysepal.translator.Translator` has to be able to find.
+
+    Args:
+        offered: Locale codes the app has catalogs for.
+        catalog: Display records, each with ``code``, ``name`` and ``flag``.
+
+    Returns:
+        One record per offered code, sorted by display name.
+    """
+    by_code = {record["code"]: record for record in catalog}
+    described = []
+    for code in offered:
+        match = by_code.get(match_offered_locale(code, by_code))
+        described.append(
+            {
+                "code": code,
+                "name": match["name"] if match else code,
+                "flag": match["flag"] if match else "",
+            }
+        )
+    return sorted(described, key=lambda record: record["name"])
+
+
+class LocaleState(HasTraits):
+    """Resolved locale code, keyed by runtime scope."""
+
+    locale = Unicode("en")
+
+    def __init__(self, locale: str = "en", **kwargs):
+        """Initialize with an initial resolved locale code."""
+        super().__init__(**kwargs)
+        self.set_locale(locale)
+
+    def set_locale(self, locale: str) -> None:
+        """Update the resolved locale; an empty value coerces to ``"en"``."""
+        self.locale = locale or "en"
+
+
+def get_current_locale_state() -> LocaleState:
+    """Return the locale state for the current runtime scope.
+
+    Locale is UI state, not session state: it is keyed by the runtime scope
+    and created on first access, so a Solara connection, a Voila page, plain
+    Jupyter, a script and pytest all get a real ``LocaleState``. There is no
+    session lookup and no credential in this path, and this function never
+    raises.
+
+    A fresh state starts at ``"en"`` and is never seeded from
+    ``~/.sepal-ui-config``, which is process-global and therefore made one
+    machine's language decide what every connection rendered in (issue #977).
+    The real preference is resolved in the browser by ``LocaleSelect.vue``
+    and pushed in from there.
+    """
+    return get_scoped_state("locale_state", LocaleState)
+
+
+def resolve_locale_state(locale_state: Optional[LocaleState] = None) -> LocaleState:
+    """Return a usable LocaleState.
+
+    Precedence: an explicit ``locale_state``, else the current scope's, which
+    :func:`get_current_locale_state` creates on demand for every runtime
+    including scripts and pytest.
+
+    Args:
+        locale_state: An explicit state to use instead of the scope's.
+
+    Returns:
+        The locale state to render with.
+    """
+    return locale_state if locale_state is not None else get_current_locale_state()
+
+
+def use_locale(locale_state: Optional[LocaleState] = None) -> str:
+    """Reactively return the resolved locale code for the current scope."""
+    locale_state = locale_state or get_current_locale_state()
+    locale, set_locale = solara.use_state(locale_state.locale)
+
+    def _observe():
+        def handler(change):
+            set_locale(change["new"])
+
+        locale_state.observe(handler, "locale")
+        return lambda: locale_state.unobserve(handler, "locale")
+
+    solara.use_effect(_observe, [id(locale_state)])
+    return locale

--- a/tests/test_sepalwidgets/test_LocaleSelect.py
+++ b/tests/test_sepalwidgets/test_LocaleSelect.py
@@ -1,6 +1,20 @@
-"""Test the LocalSelect widget."""
+"""Test both LocaleSelect widgets: the legacy v.Menu and the Vue template."""
 
+from pathlib import Path
+
+import pysepal
 from pysepal import sepalwidgets as sw
+from pysepal.sepalwidgets.vue_app import LocaleSelect
+from pysepal.solara.locale import LocaleState
+from pysepal.translator import Translator
+
+#: Absolute: tests/test_sepalwidgets/test_App.py chdirs and never restores.
+MESSAGE_DIR = Path(pysepal.__file__).parent / "message"
+
+#: pysepal ships a bare ``es`` and an ``ru-RU``; ``locale.parquet`` has neither
+#: (only ``es-ES``/``es-AR``/... and ``ru``). Both widgets used to intersect the
+#: two sets, so these two languages could never be picked.
+BUNDLED = Translator(MESSAGE_DIR)
 
 
 def test_init() -> None:
@@ -19,3 +33,84 @@ def test_change_language() -> None:
     locale_select = sw.LocaleSelect()
     locale_select._on_locale_select({"new": "fr"})
     assert locale_select.btn.children[-1] == "fr"
+
+
+def test_menu_offers_every_bundled_catalog() -> None:
+    locale_select = sw.LocaleSelect(translator=BUNDLED)
+    offered = {item.value for item in locale_select.language_list.children[0].children}
+    assert offered == set(BUNDLED.available_locales())
+
+
+def test_menu_value_is_the_locale_code() -> None:
+    """A target the parquet lacks used to leave ``value`` an empty DataFrame column."""
+    locale_select = sw.LocaleSelect(translator=Translator(MESSAGE_DIR, "es"))
+    assert locale_select.value == "es"
+
+
+def test_vue_offers_every_bundled_catalog() -> None:
+    locale_select = LocaleSelect(translator=BUNDLED)
+    offered = {record["code"] for record in locale_select.available_locales}
+    assert offered == set(BUNDLED.available_locales())
+
+
+def test_vue_accepts_bare_locale_codes() -> None:
+    """MapApp forwards codes rather than a Translator; see test_MapApp."""
+    locale_select = LocaleSelect(locales=["en", "es"])
+    assert [record["code"] for record in locale_select.available_locales] == ["en", "es"]
+
+
+def test_vue_borrows_a_display_name_for_a_bare_code() -> None:
+    locale_select = LocaleSelect(translator=BUNDLED)
+    spanish = next(r for r in locale_select.available_locales if r["code"] == "es")
+    assert spanish["name"] == "Spanish"
+
+
+def test_vue_starts_unbound() -> None:
+    assert LocaleSelect().get_locale_state() is None
+
+
+def test_vue_adopts_the_state_it_is_bound_to() -> None:
+    """Binding is the handoff point: the state already holds the resolved code."""
+    locale_select = LocaleSelect(translator=BUNDLED, locale_state=LocaleState("fr"))
+    assert locale_select.selected_locale == "fr"
+
+
+def test_a_browser_pick_reaches_the_locale_state() -> None:
+    """The frontend assigns ``selected_locale`` directly; nothing else pushes it."""
+    state = LocaleState()
+    locale_select = LocaleSelect(translator=BUNDLED, locale_state=state)
+
+    locale_select.selected_locale = "es"
+
+    assert state.locale == "es"
+
+
+def test_a_state_change_reaches_the_widget() -> None:
+    state = LocaleState()
+    locale_select = LocaleSelect(translator=BUNDLED, locale_state=state)
+
+    state.set_locale("fr")
+
+    assert locale_select.selected_locale == "fr"
+
+
+def test_rebinding_detaches_the_previous_state() -> None:
+    """Otherwise a widget reused across renders drives every state it ever saw."""
+    first, second = LocaleState(), LocaleState()
+    locale_select = LocaleSelect(locale_state=first)
+
+    locale_select.bind_locale_state(second)
+    locale_select.selected_locale = "fr"
+
+    assert second.locale == "fr"
+    assert first.locale == "en"
+
+
+def test_selecting_a_locale_writes_no_config(tmp_path, monkeypatch) -> None:
+    """v4 has no ``~/.sepal-ui-config``; the pick lives in the browser."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    locale_select = LocaleSelect(translator=BUNDLED, locale_state=LocaleState())
+
+    locale_select.selected_locale = "fr"
+
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_sepalwidgets/test_MapApp.py
+++ b/tests/test_sepalwidgets/test_MapApp.py
@@ -1,8 +1,19 @@
 """Test the MapApp widget."""
 
+from pathlib import Path
+
+import reacton
+import solara
+
+import pysepal
 from pysepal import mapping as sm
-from pysepal.sepalwidgets.vue_app import MapApp, ThemeToggle
+from pysepal.sepalwidgets.vue_app import LocaleSelect, MapApp, ThemeToggle
+from pysepal.solara.locale import LocaleState, get_current_locale_state
 from pysepal.solara.theme import ThemeState
+from pysepal.translator import Translator
+
+#: Absolute: tests/test_sepalwidgets/test_App.py chdirs and never restores.
+MESSAGE_DIR = Path(pysepal.__file__).parent / "message"
 
 
 def test_mapapp_creates_toggle_bound_to_shared_theme_state() -> None:
@@ -36,3 +47,58 @@ def test_theme_toggle_stays_unbound_without_theme_state() -> None:
     assert toggle.dark is False
 
     return
+
+
+def test_mapapp_creates_a_selector_bound_to_the_shared_locale_state() -> None:
+    """Unbound, the selector relabels itself while every string stays English."""
+    locale_state = LocaleState()
+    app = MapApp(locale_state=locale_state)
+
+    app.language_selector[0].selected_locale = "fr"
+
+    assert locale_state.locale == "fr"
+
+
+def test_mapapp_falls_back_to_the_scope_locale_state() -> None:
+    """Apps that never pass a locale_state still share one per connection."""
+    app = MapApp()
+    assert app.language_selector[0].get_locale_state() is get_current_locale_state()
+
+
+def test_mapapp_binds_a_supplied_selector() -> None:
+    locale_state = LocaleState()
+    selector = LocaleSelect()
+
+    MapApp(language_selector=[selector], locale_state=locale_state)
+
+    assert selector.get_locale_state() is locale_state
+
+
+def test_mapapp_offers_the_locales_it_is_given() -> None:
+    """Without them the default selector can only offer English."""
+    translator = Translator(MESSAGE_DIR)
+    app = MapApp(locales=translator.available_locales())
+
+    offered = {record["code"] for record in app.language_selector[0].available_locales}
+
+    assert offered == set(translator.available_locales())
+
+
+def test_mapapp_element_carries_the_locales_through_reacton() -> None:
+    """MapApp takes codes, not a Translator, because reacton flattens one.
+
+    ``Translator`` subclasses ``dict``, so reacton hands ``__init__`` a plain
+    dict and the widget cannot call ``available_locales()`` on it.
+    """
+    translator = Translator(MESSAGE_DIR)
+
+    @solara.component
+    def Demo():
+        MapApp.element(locales=translator.available_locales())
+
+    _, rc = reacton.render(Demo())
+    selector = rc.find(MapApp).widget.language_selector[0]
+
+    offered = {record["code"] for record in selector.available_locales}
+
+    assert offered == set(translator.available_locales())

--- a/tests/test_sepalwidgets/test_MapApp.py
+++ b/tests/test_sepalwidgets/test_MapApp.py
@@ -84,6 +84,43 @@ def test_mapapp_offers_the_locales_it_is_given() -> None:
     assert offered == set(translator.available_locales())
 
 
+def test_mapapp_pushes_panel_updates_into_the_child_panel() -> None:
+    """The right panel renders from a child widget built once at construction.
+
+    Nothing propagated parent -> child, so a re-render updated
+    ``MapApp.right_panel_config`` while the panel kept rendering the strings it
+    was born with -- a translated app changed its title and nothing else.
+    """
+    app = MapApp(
+        right_panel_config={"title": "Tools", "width": 400},
+        right_panel_content=[{"title": "Select AOI", "icon": "mdi-map", "content": []}],
+    )
+    panel = app.right_panel[0]
+
+    app.right_panel_config = {"title": "Herramientas", "width": 400}
+    app.right_panel_content = [{"title": "Seleccionar AOI", "icon": "mdi-map", "content": []}]
+
+    assert panel.config["title"] == "Herramientas"
+    assert panel.content_data[0]["title"] == "Seleccionar AOI"
+
+
+def test_mapapp_panel_updates_survive_a_rerender() -> None:
+    """The same thing through reacton, which is how an app actually hits it."""
+    title = solara.reactive("Tools")
+
+    @solara.component
+    def Demo():
+        MapApp.element(right_panel_config={"title": title.value, "width": 400})
+
+    _, rc = reacton.render(Demo())
+    panel = rc.find(MapApp).widget.right_panel[0]
+
+    title.value = "Herramientas"
+
+    assert rc.find(MapApp).widget.right_panel[0].config["title"] == "Herramientas"
+    assert panel.config["title"] == "Herramientas"
+
+
 def test_mapapp_element_carries_the_locales_through_reacton() -> None:
     """MapApp takes codes, not a Translator, because reacton flattens one.
 

--- a/tests/test_sepalwidgets/test_vue_templates.py
+++ b/tests/test_sepalwidgets/test_vue_templates.py
@@ -1,0 +1,42 @@
+"""ipyvue evaluates a template's ``export default`` object, not its module.
+
+A ``const`` declared beside that object -- the ordinary way to name a constant
+in a ``.vue`` file -- is therefore not in scope inside ``methods``, and every
+call raises ``ReferenceError``. ``LocaleSelect`` hit exactly this: its
+localStorage key lived in a module-level ``const``, so both the read and the
+write threw into their ``catch`` blocks and the user's language pick was
+silently never persisted.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+import pysepal
+
+VUE_FILES = sorted((Path(pysepal.__file__).parent).rglob("*.vue"))
+
+#: A binding introduced at the top level of the ``<script>`` block.
+DECLARATION = re.compile(r"^(?:const|let|var|function|class)\s+(\w+)", re.MULTILINE)
+
+
+def _module_scope_source(path: Path) -> str:
+    """Return the part of the script that precedes ``export default``."""
+    script = path.read_text().partition("<script>")[2]
+    return script.partition("export default")[0]
+
+
+def test_there_are_vue_files_to_check():
+    """Guard the guard: a bad glob would make every assertion below vacuous."""
+    assert VUE_FILES
+
+
+@pytest.mark.parametrize("path", VUE_FILES, ids=lambda p: p.name)
+def test_no_binding_is_declared_outside_the_exported_object(path: Path):
+    declared = DECLARATION.findall(_module_scope_source(path))
+    assert declared == [], (
+        f"{path.name} declares {declared} beside `export default`. ipyvue does not "
+        "evaluate the script as a module, so these are undefined inside methods. "
+        "Inline the value, or put it on the exported object."
+    )

--- a/tests/test_solara/test_locale.py
+++ b/tests/test_solara/test_locale.py
@@ -1,0 +1,132 @@
+"""Tests for scope-keyed locale-state resolution and the offered-locale matcher."""
+
+import pytest
+
+import pysepal.solara.locale as locale_mod
+from pysepal.solara import scope_registry
+from pysepal.solara.locale import (
+    LocaleState,
+    describe_offered_locales,
+    get_current_locale_state,
+    match_offered_locale,
+    resolve_locale_state,
+)
+from pysepal.solara.runtime_context import UnsupportedSolaraRuntimeError
+
+CATALOG = [
+    {"code": "en", "name": "English", "flag": "gb"},
+    {"code": "fr", "name": "French", "flag": "fr"},
+    {"code": "es-ES", "name": "Spanish", "flag": "es"},
+    {"code": "es-MX", "name": "Spanish, Mexico", "flag": "mx"},
+    {"code": "ru", "name": "Russian", "flag": "ru"},
+]
+
+
+def test_match_prefers_an_exact_code():
+    assert match_offered_locale("pt-BR", ["pt", "pt-BR"]) == "pt-BR"
+
+
+def test_match_falls_back_to_the_bare_primary_subtag():
+    """navigator.language reports es-CL where the app only ships es."""
+    assert match_offered_locale("es-CL", ["en", "es"]) == "es"
+
+
+def test_match_falls_back_to_an_offered_variant_of_the_same_primary():
+    """The reverse case: the browser says pt, the app only ships pt-BR."""
+    assert match_offered_locale("pt", ["en", "pt-BR"]) == "pt-BR"
+
+
+def test_match_takes_the_first_offered_variant():
+    assert match_offered_locale("es", ["es-MX", "es-ES"]) == "es-MX"
+
+
+def test_match_returns_empty_so_the_caller_can_fall_through():
+    assert match_offered_locale("de", ["en", "fr"]) == ""
+    assert match_offered_locale("", ["en"]) == ""
+
+
+def test_describe_keeps_every_offered_code():
+    """The app's catalogs are authoritative; the parquet only supplies labels.
+
+    Filtering with ``code.isin(...)`` silently dropped any catalog the parquet
+    lacked -- including pysepal's own bundled ``message/es/``, which the picker
+    could therefore never offer.
+    """
+    described = describe_offered_locales(["en", "es", "ru-RU"], CATALOG)
+    assert [record["code"] for record in described] == ["en", "ru-RU", "es"]
+
+
+def test_describe_borrows_the_label_of_a_matching_variant():
+    """A bare ``es`` keeps its own code but shows up as Spanish."""
+    (record,) = describe_offered_locales(["es"], CATALOG)
+    assert record == {"code": "es", "name": "Spanish", "flag": "es"}
+
+
+def test_describe_labels_an_unknown_code_with_itself():
+    """Never drop a catalog just because the parquet has never heard of it."""
+    (record,) = describe_offered_locales(["xx-YY"], CATALOG)
+    assert record == {"code": "xx-YY", "name": "xx-YY", "flag": ""}
+
+
+def test_describe_sorts_by_display_name():
+    described = describe_offered_locales(["ru", "en", "fr"], CATALOG)
+    assert [record["name"] for record in described] == ["English", "French", "Russian"]
+
+
+def test_locale_state_coerces_an_empty_code_to_english():
+    state = LocaleState("")
+    assert state.locale == "en"
+    state.set_locale("")
+    assert state.locale == "en"
+
+
+def test_resolve_returns_explicit_locale_state():
+    """An explicitly provided locale_state wins over any scope lookup."""
+    state = LocaleState("fr")
+    assert resolve_locale_state(state) is state
+
+
+def test_resolve_uses_current_locale_state_when_available(monkeypatch):
+    scoped = LocaleState("fr")
+    monkeypatch.setattr(locale_mod, "get_current_locale_state", lambda: scoped)
+    assert resolve_locale_state() is scoped
+
+
+def test_resolve_locale_state_does_not_swallow_errors(monkeypatch):
+    """A guard that only exists for monkeypatched symbols hides real failures."""
+
+    def _boom():
+        raise UnsupportedSolaraRuntimeError("no runtime")
+
+    monkeypatch.setattr(locale_mod, "get_current_locale_state", _boom)
+    with pytest.raises(UnsupportedSolaraRuntimeError):
+        resolve_locale_state()
+
+
+def test_current_locale_state_is_stable_per_scope(monkeypatch):
+    monkeypatch.setattr(scope_registry, "current_scope_id", lambda: "kernel-a")
+    assert get_current_locale_state() is get_current_locale_state()
+
+
+def test_current_locale_state_is_isolated_per_scope(monkeypatch):
+    """Two connections must not share a language."""
+    monkeypatch.setattr(scope_registry, "current_scope_id", lambda: "kernel-a")
+    first = get_current_locale_state()
+    monkeypatch.setattr(scope_registry, "current_scope_id", lambda: "kernel-b")
+    assert get_current_locale_state() is not first
+
+
+def test_current_locale_state_never_raises_without_a_session(monkeypatch):
+    """Locale is UI state; it has no business failing on an auth condition."""
+    monkeypatch.setattr(scope_registry, "current_scope_id", lambda: "kernel-a")
+    assert isinstance(get_current_locale_state(), LocaleState)
+
+
+def test_a_fresh_scope_starts_at_english(monkeypatch):
+    """The default is a constant, never a read of the machine's config file.
+
+    This is what makes a downstream test suite deterministic: before v4 the
+    language a test saw was whatever ``~/.sepal-ui-config`` happened to hold.
+    """
+    monkeypatch.setattr(scope_registry, "current_scope_id", lambda: "kernel-fresh")
+    assert get_current_locale_state().locale == "en"

--- a/tests/test_solara/test_public_surface.py
+++ b/tests/test_solara/test_public_surface.py
@@ -11,6 +11,7 @@ INIT_PATH = Path(ps.__file__)
 #: cannot pass unnoticed: a diff here is the record that the decision was taken.
 SEALED_SURFACE = frozenset(
     {
+        "LocaleState",
         "MissingSepalHeadersError",
         "NotificationProvider",
         "PROCESS_SCOPE",
@@ -25,6 +26,7 @@ SEALED_SURFACE = frozenset(
         "current_scope_id",
         "get_current_drive_interface",
         "get_current_gee_interface",
+        "get_current_locale_state",
         "get_current_sepal_client",
         "get_current_session_info",
         "get_current_theme_state",
@@ -33,12 +35,14 @@ SEALED_SURFACE = frozenset(
         "has_scoped_state",
         "notify",
         "prime_dev_auth",
+        "resolve_locale_state",
         "resolve_scope_id",
         "resolve_theme_state",
         "setup_sessions",
         "setup_solara_server",
         "setup_theme_colors",
         "track_task",
+        "use_locale",
         "use_notifications",
         "use_theme_dark",
         "with_sepal_sessions",

--- a/tests/test_translator/test_catalog_keys.py
+++ b/tests/test_translator/test_catalog_keys.py
@@ -1,0 +1,49 @@
+"""A catalog key must not shadow a dict attribute.
+
+``Translator`` subclasses ``Box`` subclasses ``dict``, so ``cm.buttons.clear``
+returns ``dict.clear`` -- a bound method -- rather than the translated string,
+with no error anywhere. It reaches the UI as
+``<bound method Box.clear of Box({...})>``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import pysepal
+
+REPO_ROOT = Path(pysepal.__file__).parent.parent
+
+CATALOGS = sorted(
+    path
+    for root in (Path(pysepal.__file__).parent, REPO_ROOT / "demo_apps")
+    if root.is_dir()
+    for path in root.rglob("message/**/*.json")
+)
+
+SHADOWED = frozenset(dir(dict))
+
+
+def _keys(node, prefix=""):
+    """Yield every dotted key path in a catalog."""
+    for key, value in node.items():
+        yield f"{prefix}{key}"
+        if isinstance(value, dict):
+            yield from _keys(value, f"{prefix}{key}.")
+
+
+def test_catalogs_are_discovered():
+    """Guard the guard: a bad glob would make the check below vacuous."""
+    assert CATALOGS
+
+
+@pytest.mark.parametrize("path", CATALOGS, ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_no_key_shadows_a_dict_attribute(path: Path):
+    clashing = [
+        key for key in _keys(json.loads(path.read_text())) if key.split(".")[-1] in SHADOWED
+    ]
+    assert clashing == [], (
+        f"{path} uses {clashing}, which dict already defines. Attribute access "
+        "returns the method, not the translation. Rename the key."
+    )


### PR DESCRIPTION
Stacked on #1026, which removes `~/.sepal-ui-config` — the only thing that made a language choice persist. On its own, v4 ships a picker whose selection is dropped on the floor and lost on refresh. This is the replacement: `LocaleSelect` resolves the locale in the browser (`localStorage` → `navigator.language` → `en`, each candidate matched against the catalogs the app actually ships) and pushes the result into a scope-keyed `LocaleState`, exactly as theme already works. Build the `Translator` from `use_locale()` and a language change re-renders in place, no reload.

Reworked from #1011, which was written against 3.x — its `SessionManager` registration, process-global fallback and `~/.sepal-ui-config` seed all target things v4 deletes, so they are gone rather than ported. Two fixes beyond that PR:

- **`MapApp` takes locale codes, not a `Translator`.** `Translator` subclasses `dict` and reacton flattens dict props, so `translator=` raises `AttributeError` through `MapApp.element()` — which is how every Solara app builds it. #1011 only exercised direct construction.
- **Both selectors now offer every catalog the app ships.** The offered list used to be intersected with `locale.parquet`, which has `es-ES` but no bare `es`, so pysepal's own `message/es/` and `message/ru-RU/` could never be selected. The `v.Menu` selector also handed out a pandas Series as its public `value` whenever the target was missing from the parquet.

Full suite green — 760 passed against 727 on the base, same 5 pre-existing errors — over two randomized-order runs, plus `pre-commit run --all-files`. The browser half has no JS harness (same coverage level as `Theming.vue`), but the resolve → state → re-render loop is verified end to end through a reacton render.

Unrelated landmine found on the way, not fixed here: `tests/test_sepalwidgets/test_App.py:144` `os.chdir`s without restoring, so every test after it runs from the wrong directory.