### PR TITLE
fix(solara/session): scope a dev-auth session per connection

### DIFF
--- a/pysepal/scripts/gee_interface.py
+++ b/pysepal/scripts/gee_interface.py
@@ -48,11 +48,12 @@ def _refuse_ambient_session_per_connection() -> None:
     """
     # Local: pysepal.solara.session_manager imports this module, so neither of
     # these can be a module-level import.
-    from pysepal.solara._topology import SessionSource
     from pysepal.solara.errors import SepalSessionError
-    from pysepal.solara.session_manager import _current_plan
+    from pysepal.solara.session_manager import _current_plan, _is_scoped_per_connection
 
-    if _current_plan().source is not SessionSource.PER_CONNECTION:
+    # Use the rule of the session layer, so the guard always agrees with it.
+    # A dev-auth runtime that serves a connection refuses what production refuses.
+    if not _is_scoped_per_connection(_current_plan()):
         return
 
     raise SepalSessionError(

--- a/pysepal/solara/_topology.py
+++ b/pysepal/solara/_topology.py
@@ -250,3 +250,19 @@ def current_session_plan(*, has_sepal_headers: bool) -> SessionPlan:
         using_solara_server=solara._using_solara_server(),
         has_sepal_headers=has_sepal_headers,
     )
+
+
+def is_serving_connections() -> bool:
+    """Whether a Solara server runs this process, with one kernel per connection.
+
+    This is the signal of rule 4. The session layer also reads it to decide if
+    ``DEV_AUTH`` scopes per connection.
+
+    Do not use ``resolve_scope_id()`` here. It uses IPython and also makes an
+    event loop, even when it fails, but the ``gee_interface`` guard must refuse
+    before a loop exists.
+
+    Returns:
+        True when a Solara server runs this process.
+    """
+    return solara._using_solara_server()

--- a/pysepal/solara/session_manager.py
+++ b/pysepal/solara/session_manager.py
@@ -26,6 +26,7 @@ from pysepal.solara._topology import (
     SessionSource,
     current_session_plan,
     is_sepal_sandbox,
+    is_serving_connections,
     plan_reads_sepal_headers,
 )
 from pysepal.solara.dev_auth import prime_dev_auth
@@ -134,6 +135,31 @@ def _carries_sepal_headers() -> bool:
     except ValidationError:
         return False
     return True
+
+
+def _is_scoped_per_connection(plan: SessionPlan) -> bool:
+    """Whether the session of this plan belongs to one connection, not the process.
+
+    The credential source and the session scope are two different decisions.
+    ``PYSEPAL_DEV_AUTH`` gives the app-launcher shape on a local machine, thus it
+    must also scope like it. A process session makes several tabs look like one
+    connection and keeps interfaces alive across reloads. The developer login
+    stays in the process cache in :func:`prime_dev_auth`. Only the session is
+    per scope.
+
+    ``DEV_AUTH`` is per connection only where connections exist. A notebook, a
+    script and pytest have no kernel for a session key, thus they keep the
+    process session.
+
+    Args:
+        plan: The resolved credential plan.
+
+    Returns:
+        True when the session is per connection.
+    """
+    if plan.source is SessionSource.PER_CONNECTION:
+        return True
+    return plan.source is SessionSource.DEV_AUTH and is_serving_connections()
 
 
 def _current_plan() -> SessionPlan:
@@ -257,12 +283,12 @@ class SessionManager:
             EEClientError: For authentication-related errors.
         """
         plan = _current_plan()
-        if plan.source is SessionSource.PER_CONNECTION:
-            self._create_connection_session(module_name)
+        if _is_scoped_per_connection(plan):
+            self._create_connection_session(module_name, plan)
         else:
             self._ensure_process_session(plan, module_name)
 
-    def _create_connection_session(self, module_name: str) -> None:
+    def _create_connection_session(self, module_name: str, plan: SessionPlan) -> None:
         """Create -- or reuse -- this connection's session from its SEPAL headers.
 
         The common case is the raw-header fast path: the same connection hands
@@ -274,8 +300,14 @@ class SessionManager:
         failure for a new ``module_name`` propagates as-is and leaves the
         session -- and its other modules' clients -- intact.
 
+        Under ``DEV_AUTH`` the connection has no SEPAL headers, because there is
+        no SEPAL proxy in front of a local ``solara run``. The identity comes
+        from the process-cached developer login. The lifetime is the same either
+        way, which is the point.
+
         Args:
             module_name: The module name for the SepalClient.
+            plan: The resolved credential plan, which selects the identity source.
 
         Raises:
             MissingSepalHeadersError: The connection carries no valid SEPAL headers.
@@ -293,7 +325,10 @@ class SessionManager:
                 "refusing to create a per-connection session there."
             )
 
-        current_headers = headers.value
+        dev_auth = plan.source is SessionSource.DEV_AUTH
+        # prime_dev_auth is the process cache: one blocking POST for the
+        # process, not one for each connection.
+        current_headers = _require_session_id(prime_dev_auth()) if dev_auth else headers.value
         if current_headers is None:
             raise MissingSepalHeadersError(
                 f"No SEPAL authentication headers are available for scope {scope_id}; "
@@ -313,7 +348,9 @@ class SessionManager:
                 self._ensure_sepal_client(existing, module_name)
                 return
 
-            sepal_headers = resolve_sepal_headers(current_headers)
+            # prime_dev_auth returns parsed SepalHeaders. Only a real
+            # connection gives a raw dict that you must parse.
+            sepal_headers = current_headers if dev_auth else resolve_sepal_headers(current_headers)
             username = sepal_headers.sepal_user.username
             sepal_session_id = sepal_headers.cookies["SEPAL-SESSIONID"]
 
@@ -630,7 +667,7 @@ class SessionManager:
             SepalSessionError: A per-connection runtime has no session yet.
         """
         plan = _current_plan()
-        if plan.source is SessionSource.PER_CONNECTION:
+        if _is_scoped_per_connection(plan):
             return self._require_connection_session()["gee_interface"]
 
         with self._registry.scope_lock(PROCESS_SCOPE):
@@ -647,7 +684,7 @@ class SessionManager:
             SepalSessionError: A per-connection runtime has no session yet.
         """
         plan = _current_plan()
-        if plan.source is SessionSource.PER_CONNECTION:
+        if _is_scoped_per_connection(plan):
             return self._require_connection_session()["drive_interface"]
 
         with self._registry.scope_lock(PROCESS_SCOPE):
@@ -688,7 +725,7 @@ class SessionManager:
         """
         if scope_id is None:
             plan = _current_plan()
-            if plan.source is not SessionSource.PER_CONNECTION:
+            if not _is_scoped_per_connection(plan):
                 with self._registry.scope_lock(PROCESS_SCOPE):
                     process_session = self._ensure_process_session_locked(plan)
                     name = module_name or process_session["active_module_name"]

--- a/tests/test_scripts/test_gee_interface_topology_guard.py
+++ b/tests/test_scripts/test_gee_interface_topology_guard.py
@@ -192,3 +192,34 @@ def test_is_running_reads_the_task_state_off_the_model(state, expected):
         assert interface.is_running("my-export") is expected
     finally:
         interface.close()
+
+
+def test_dev_auth_serving_a_connection_refuses_a_session_less_interface():
+    """Dev-auth must refuse what production refuses.
+
+    With a solara connection, a session-less interface reads the Earth Engine
+    credentials of the machine, not those of the session. ``PYSEPAL_DEV_AUTH``
+    exists to show that fault on a local machine. Without a connection the
+    machine credentials are correct, which the test above pins.
+    """
+    with _topology(DEV_AUTH) as stubs:
+        with patch.object(session_manager_module, "is_serving_connections", lambda: True):
+            with pytest.raises(SepalSessionError, match="platform service account"):
+                GEEInterface()
+
+    assert stubs.new_event_loop.call_count == 0
+
+
+def test_the_guard_creates_no_event_loop_deciding_about_dev_auth():
+    """The decision must make no event loop, whatever the result is.
+
+    The guard refuses before the loop exists. An earlier version used
+    ``resolve_scope_id()``, which makes an event loop even when it fails. Thus
+    the decision leaked what the guard prevents.
+    """
+    with _topology(DEV_AUTH) as stubs:
+        with patch.object(gee_interface_module.EESession, "from_default", return_value=MagicMock()):
+            GEEInterface()
+
+    # One loop, built by the interface itself -- none from the decision.
+    assert stubs.new_event_loop.call_count == 1

--- a/tests/test_solara/test_dev_auth_scoping.py
+++ b/tests/test_solara/test_dev_auth_scoping.py
@@ -1,0 +1,136 @@
+"""DEV_AUTH has the topology of production: one session for each connection.
+
+``PYSEPAL_DEV_AUTH`` lets a developer run the app-launcher shape on a local
+machine. This is correct only if the scope agrees: one session for each
+connection, which stops with its kernel. A process session makes three browser
+tabs look like one user and keeps interfaces alive across page reloads.
+
+The developer login stays in the process cache, because it is a blocking HTTP
+POST and there is one developer identity. Only the session is per connection.
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pysepal.solara import session_manager as sm
+from pysepal.solara._topology import SessionPlan, SessionSource
+
+_DEV_AUTH = SessionPlan(SessionSource.DEV_AUTH, "test")
+
+
+def _dev_headers(username="alice"):
+    return SimpleNamespace(
+        sepal_user=SimpleNamespace(username=username),
+        cookies={"SEPAL-SESSIONID": "sid-1"},
+        session_id="sid-1",
+    )
+
+
+@contextmanager
+def _dev_stack(scope_id, headers=None):
+    """Patch the constructors a dev-auth session reaches, pinned to one scope."""
+    gee_factory = MagicMock(side_effect=lambda *a, **k: MagicMock())
+    drive_factory = MagicMock(side_effect=lambda **k: MagicMock())
+    sepal_factory = MagicMock(
+        side_effect=lambda **k: SimpleNamespace(
+            ensure_results_dir=MagicMock(), module_name=k.get("module_name")
+        )
+    )
+    prime = MagicMock(return_value=headers or _dev_headers())
+
+    with (
+        patch.object(sm, "_current_plan", return_value=_DEV_AUTH),
+        patch.object(sm, "is_sepal_sandbox", return_value=False),
+        patch.object(
+            sm,
+            "EESession",
+            SimpleNamespace(
+                from_default=MagicMock(side_effect=lambda **k: MagicMock()),
+                from_sepal_headers=MagicMock(side_effect=lambda _h: MagicMock()),
+            ),
+        ),
+        patch.object(sm, "GEEInterface", gee_factory),
+        patch.object(sm, "GDriveInterface", drive_factory),
+        patch.object(sm, "SepalClient", SimpleNamespace(create=sepal_factory)),
+        patch.object(sm, "prime_dev_auth", prime),
+        patch.object(sm, "_RESULTS_DIR_EXECUTOR", SimpleNamespace(submit=lambda fn: fn())),
+        patch.object(sm.SessionManager, "get_scope_id", lambda _self: scope_id),
+        # Dev-auth is per connection only when a solara server serves them.
+        # Under pytest the real function gives False.
+        patch.object(sm, "is_serving_connections", lambda: scope_id != sm.PROCESS_SCOPE),
+    ):
+        yield SimpleNamespace(gee=gee_factory, prime=prime, sepal=sepal_factory)
+
+
+def test_two_connections_get_two_sessions():
+    """Two tabs are two users' worth of state, exactly as on SEPAL."""
+    manager = sm.SessionManager()
+
+    with _dev_stack("kernel-a"):
+        manager.create_session("demo")
+        first = manager.get_gee_interface()
+
+    with _dev_stack("kernel-b"):
+        manager.create_session("demo")
+        second = manager.get_gee_interface()
+
+    assert first is not second
+
+
+def test_a_reload_does_not_reuse_the_previous_kernels_session():
+    """The fault this corrects: an interface that continues after its loop."""
+    manager = sm.SessionManager()
+
+    with _dev_stack("kernel-a"):
+        manager.create_session("demo")
+        before = manager.get_gee_interface()
+    manager.cleanup_session("kernel-a")
+
+    with _dev_stack("kernel-b"):
+        manager.create_session("demo")
+        after = manager.get_gee_interface()
+
+    assert after is not before
+
+
+def test_the_developer_login_is_not_repeated_per_connection():
+    """The blocking POST stays in the process cache. Only the session is per scope."""
+    manager = sm.SessionManager()
+
+    with _dev_stack("kernel-a") as first:
+        manager.create_session("demo")
+    with _dev_stack("kernel-b") as second:
+        manager.create_session("demo")
+
+    # prime_dev_auth is the process cache, thus each scope can call it. But no
+    # code must go around it to a new login path.
+    assert first.prime.called
+    assert second.prime.called
+
+
+def test_cleanup_closes_a_dev_auth_session():
+    """A kernel that stops must release the session, as it does on SEPAL."""
+    manager = sm.SessionManager()
+
+    with _dev_stack("kernel-a"):
+        manager.create_session("demo")
+        assert manager._registry.get("kernel-a") is not None
+
+    manager.cleanup_session("kernel-a")
+
+    assert manager._registry.get("kernel-a") is None
+
+
+def test_without_a_connection_dev_auth_keeps_the_process_session():
+    """A notebook, a script or pytest has no kernel for a session key.
+
+    ``resolve_scope_id`` gives ``PROCESS_SCOPE`` there, and a per-connection
+    session refuses that scope. Thus these runtimes keep the process session.
+    """
+    manager = sm.SessionManager()
+
+    with _dev_stack(sm.PROCESS_SCOPE):
+        manager.create_session("demo")
+
+        assert manager._registry.get(sm.PROCESS_SCOPE) is not None


### PR DESCRIPTION
Bottom of a two-PR stack. #1031 is on top of this one.

`PYSEPAL_DEV_AUTH` lets you run the app-launcher shape on a local machine, but it made one session for the full process. Thus three browser tabs looked like one user, a page reload used the session of the previous kernel, and a fault in one connection stayed hidden until the code ran on SEPAL.

The session is now per connection, as in production. The credential source and the session scope are now two decisions, not one. The developer login stays in the process cache, because it is a blocking POST and there is one developer identity. Only the session is per scope. `PER_CONNECTION` does not change. The second commit gives the `GEEInterface` guard the same rule, so the guard always agrees with the session layer.

There is one limit. `DEV_AUTH` is per connection only where a connection exists. A notebook, a script and pytest have no kernel for a session key, thus they keep the process session.

Cause: a page reload gave `RuntimeError: unable to perform operation on <TCPTransport closed=True ...>`. Solara gives each kernel one event loop and closes the loop at a reload, but the process session kept an `httpx` client that was bound to the closed loop. This PR corrects the pysepal part. The client must also not continue after its loop, which is dfguerrerom/ee-client#37.

Tests: 931 pass. The failures that remain are also on `main`. Verified with two browser tabs on a dev-auth server: five connections gave five different scope ids and five different `GEEInterface` objects, and no process session.

AI-Agent: claude-opus-5[1m]
