### PR TITLE
fix(mapping): make the background basemaps configurable

### DIFF
--- a/pysepal/mapping/basemaps.py
+++ b/pysepal/mapping/basemaps.py
@@ -1,5 +1,6 @@
 """Module to load basemaps from different providers."""
 
+import os
 from typing import Optional
 
 from box import Box
@@ -7,7 +8,36 @@ from ipyleaflet import TileLayer
 from xyzservices import TileProvider
 from xyzservices import providers as xyz
 
+# CARTO started watermarking its raster tiles when they are requested without an API
+# key, so the background defaults point at a keyless provider. A deployment overrides
+# them through the environment with full XYZ URL templates, which keeps any API key out
+# of the published package.
+BASEMAP_LIGHT: str = os.getenv(
+    "PYSEPAL_BASEMAP_LIGHT",
+    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+)
+"URL template of the light background basemap."
+
+BASEMAP_DARK: str = os.getenv(
+    "PYSEPAL_BASEMAP_DARK",
+    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+)
+"URL template of the dark background basemap."
+
+BASEMAP_ATTRIBUTION: str = os.getenv("PYSEPAL_BASEMAP_ATTRIBUTION", "Esri")
+"Attribution of the background basemaps. Must match the provider the URLs point at."
+
 xyz_tiles: dict = {
+    "SEPAL_LIGHT": {
+        "url": BASEMAP_LIGHT,
+        "attribution": BASEMAP_ATTRIBUTION,
+        "name": "SEPAL Light",
+    },
+    "SEPAL_DARK": {
+        "url": BASEMAP_DARK,
+        "attribution": BASEMAP_ATTRIBUTION,
+        "name": "SEPAL Dark",
+    },
     "OpenStreetMap": {
         "url": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         "attribution": "OpenStreetMap",

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -130,7 +130,7 @@ class SepalMap(ipl.Map):
         """Custom Map object design to build application.
 
         The SepalMap class inherits from ipyleaflet.Map. It can thus be initialized with all its parameter.
-        The map will fall back to CartoDB.DarkMatter map that well fits with the rest of the pysepal layout.
+        The map will fall back to the SEPAL dark background that well fits with the rest of the pysepal layout.
         Numerous methods have been added in the class to help you deal with your workflow implementation.
         It can natively display raster from .tif files and files and ee objects using methods
         that have the same signature as the GEE JavaScripts console.
@@ -195,13 +195,11 @@ class SepalMap(ipl.Map):
         # add the basemaps
         self.clear()
         theme_source = self._resolve_theme_source(theme_state, theme_toggle)
-        default_basemap = (
-            "CartoDB.DarkMatter" if self._theme_is_dark(theme_source) else "CartoDB.Positron"
-        )
+        default_basemap = "SEPAL_DARK" if self._theme_is_dark(theme_source) else "SEPAL_LIGHT"
         basemaps = basemaps or [default_basemap]
         [self.add_basemap(basemap) for basemap in set(basemaps)]
 
-        self._apply_theme_class(default_basemap == "CartoDB.DarkMatter")
+        self._apply_theme_class(default_basemap == "SEPAL_DARK")
 
         # set the visibility of all the basemaps to False but the first one
         [setattr(lyr, "visible", False) for lyr in self.layers]
@@ -237,8 +235,8 @@ class SepalMap(ipl.Map):
     def _on_theme_change(self, change) -> None:
         """Change the basemap layer."""
         # This is the way to make it work in solara do not ask me why
-        light = eval(str(basemap_tiles["CartoDB.Positron"]))
-        dark = eval(str(basemap_tiles["CartoDB.DarkMatter"]))
+        light = eval(str(basemap_tiles["SEPAL_LIGHT"]))
+        dark = eval(str(basemap_tiles["SEPAL_DARK"]))
 
         layer_names = [layer.name for layer in self.layers]
         self._apply_theme_class(change["new"])

--- a/tests/test_mapping/test_LayersControl.py
+++ b/tests/test_mapping/test_LayersControl.py
@@ -25,7 +25,7 @@ def test_init() -> None:
     assert len(vector_rows) == 0
     assert len(layer_rows) == 0
     assert len(base_rows) == 1
-    assert "CartoDB" in base_rows[0].children[0].children[0]
+    assert "SEPAL" in base_rows[0].children[0].children[0]
 
     return
 
@@ -69,7 +69,7 @@ def test_add_basemaps() -> None:
 
     assert len(layer_rows) == 0
     assert len(base_rows) == 2
-    assert "CartoDB" in base_rows[0].children[0].children[0]
+    assert "SEPAL" in base_rows[0].children[0].children[0]
     assert "Google Satellite" in base_rows[1].children[0].children[0]
 
     return

--- a/tests/test_mapping/test_SepalMap.py
+++ b/tests/test_mapping/test_SepalMap.py
@@ -34,16 +34,17 @@ def test_init() -> None:
     assert m.zoom == 2
     assert len(m.layers) == 2
 
-    basemaps = ["CartoDB.DarkMatter", "CartoDB.Positron"]
+    default_basemaps = ["SEPAL Dark", "SEPAL Light"]
 
     # Get current theme
     dark_theme = bool(v.theme.dark)
 
     # The basemap will change depending on the current theme.
-    assert m.layers[0].name == basemaps[not dark_theme]
+    assert m.layers[0].name == default_basemaps[not dark_theme]
 
     # check that the map start with several basemaps
 
+    basemaps = ["CartoDB.DarkMatter", "CartoDB.Positron"]
     m = sm.SepalMap(basemaps)
     assert len(m.layers) == 3
     layers_name = [layer.name for layer in m.layers]
@@ -76,15 +77,15 @@ def test_theme_toggle_is_deprecated_but_still_follows_bound_theme_state() -> Non
     with pytest.deprecated_call(match="theme_toggle"):
         m = sm.SepalMap(theme_toggle=first_toggle, gee=False)
 
-    assert m.layers[0].name == "CartoDB.Positron"
+    assert m.layers[0].name == "SEPAL Light"
 
     second_toggle = ThemeToggle(theme_state=theme_state)
     second_toggle.dark = True
 
-    assert m.layers[0].name == "CartoDB.DarkMatter"
+    assert m.layers[0].name == "SEPAL Dark"
 
     first_toggle.dark = False
-    assert m.layers[0].name == "CartoDB.Positron"
+    assert m.layers[0].name == "SEPAL Light"
 
     return
 
@@ -520,7 +521,7 @@ def test_find_layer(ee_map_with_layers: sm.SepalMap) -> None:
 
     # search including the basemap
     res = m.find_layer(0, base=True)
-    assert "Carto" in res.name
+    assert "SEPAL" in res.name
     assert res.base is True
 
     # search something that is not a key

--- a/tests/test_sepalwidgets/test_MapApp.py
+++ b/tests/test_sepalwidgets/test_MapApp.py
@@ -24,17 +24,17 @@ def test_mapapp_creates_toggle_bound_to_shared_theme_state() -> None:
     app = MapApp(main_map=[sepal_map], theme_state=theme_state)
     toggle = app.theme_toggle[0]
 
-    assert sepal_map.layers[0].name == "CartoDB.Positron"
+    assert sepal_map.layers[0].name == "SEPAL Light"
 
     toggle.dark = True
-    assert sepal_map.layers[0].name == "CartoDB.DarkMatter"
+    assert sepal_map.layers[0].name == "SEPAL Dark"
 
     toggle.dark = None
     toggle.resolved_dark = False
-    assert sepal_map.layers[0].name == "CartoDB.Positron"
+    assert sepal_map.layers[0].name == "SEPAL Light"
 
     toggle.resolved_dark = True
-    assert sepal_map.layers[0].name == "CartoDB.DarkMatter"
+    assert sepal_map.layers[0].name == "SEPAL Dark"
 
     return
 


### PR DESCRIPTION
CARTO now watermarks its raster tiles when they are requested without an API key, so the default light and dark backgrounds show "API KEY REQUIRED" across the map.

The two backgrounds become `SEPAL_LIGHT` and `SEPAL_DARK` entries whose URLs are read from `PYSEPAL_BASEMAP_LIGHT`, `PYSEPAL_BASEMAP_DARK` and `PYSEPAL_BASEMAP_ATTRIBUTION`. They default to a keyless Esri layer so that no key ever ships in the package, and a deployment injects a CARTO key through the environment. The 2.22.x maintenance line reads the same variables, so a single env block serves both.

Dropping the `CartoDB.*` lookups also removes a latent crash: those names come from the xyzservices free-provider list, which still reports CartoDB as keyless. Once that is corrected upstream the entries disappear and `SepalMap` fails with a `KeyError` at startup.

Tests asserting the default basemap were updated. The ones that pass `CartoDB.Positron` as an explicit basemap still exercise it and are unchanged.