### PR TITLE
fix(mapping): drive the CARTO backgrounds off a single API key

### DIFF
--- a/pysepal/mapping/basemaps.py
+++ b/pysepal/mapping/basemaps.py
@@ -14,12 +14,8 @@ from xyzservices import providers as xyz
 CARTODB_BASEMAP_KEY: str = os.getenv("CARTODB_BASEMAP_KEY", "")
 "API key for the CARTO backgrounds. Unset means the keyless Esri fallback."
 
-ESRI_LIGHT: str = (
-    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
-)
-ESRI_DARK: str = (
-    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
-)
+ESRI_LIGHT: str = "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+ESRI_DARK: str = "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
 
 BASEMAP_LIGHT: str = (
     f"https://basemaps.cartocdn.com/light_all/{{z}}/{{x}}/{{y}}.png?key={CARTODB_BASEMAP_KEY}"

--- a/pysepal/mapping/basemaps.py
+++ b/pysepal/mapping/basemaps.py
@@ -8,24 +8,37 @@ from ipyleaflet import TileLayer
 from xyzservices import TileProvider
 from xyzservices import providers as xyz
 
-# CARTO started watermarking its raster tiles when they are requested without an API
-# key, so the background defaults point at a keyless provider. A deployment overrides
-# them through the environment with full XYZ URL templates, which keeps any API key out
-# of the published package.
-BASEMAP_LIGHT: str = os.getenv(
-    "PYSEPAL_BASEMAP_LIGHT",
-    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+# CARTO watermarks its raster tiles when they are requested without an API key. The
+# key is a deployment secret, so it arrives through the environment and never ships in
+# the package; without it the backgrounds fall back to a keyless provider.
+CARTODB_BASEMAP_KEY: str = os.getenv("CARTODB_BASEMAP_KEY", "")
+"API key for the CARTO backgrounds. Unset means the keyless Esri fallback."
+
+ESRI_LIGHT: str = (
+    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+)
+ESRI_DARK: str = (
+    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+)
+
+BASEMAP_LIGHT: str = (
+    f"https://basemaps.cartocdn.com/light_all/{{z}}/{{x}}/{{y}}.png?key={CARTODB_BASEMAP_KEY}"
+    if CARTODB_BASEMAP_KEY
+    else ESRI_LIGHT
 )
 "URL template of the light background basemap."
 
-BASEMAP_DARK: str = os.getenv(
-    "PYSEPAL_BASEMAP_DARK",
-    "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+BASEMAP_DARK: str = (
+    f"https://basemaps.cartocdn.com/dark_all/{{z}}/{{x}}/{{y}}.png?key={CARTODB_BASEMAP_KEY}"
+    if CARTODB_BASEMAP_KEY
+    else ESRI_DARK
 )
 "URL template of the dark background basemap."
 
-BASEMAP_ATTRIBUTION: str = os.getenv("PYSEPAL_BASEMAP_ATTRIBUTION", "Esri")
-"Attribution of the background basemaps. Must match the provider the URLs point at."
+# Tied to the key so the credit can never drift from the provider actually serving the
+# tiles; CARTO's free tier is granted in exchange for it staying visible.
+BASEMAP_ATTRIBUTION: str = "CARTO, OpenStreetMap" if CARTODB_BASEMAP_KEY else "Esri"
+"Attribution of the background basemaps."
 
 xyz_tiles: dict = {
     "SEPAL_LIGHT": {


### PR DESCRIPTION
Follow-up to #1035. The three variables that PR introduced collapse into one, `CARTODB_BASEMAP_KEY`.

A deployment now injects only the secret and the library owns the rest. Attribution is derived from the same key, so the credit CARTO's free tier requires cannot drift away from the tiles actually being served — with the URLs and the attribution as separate variables, setting one and forgetting the other was a licensing problem waiting to happen. Clearing the key is the whole rollback to the keyless Esri fallback.