### PR TITLE
build: floor ipyvuetify at 1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ dependencies = [
     # building widgets
     "tomli",
     "ipykernel",
-    "ipyvuetify<3", # 3.0 drops widgets sepalwidgets subclasses (CalendarDaily), so an unpinned install cannot import pysepal
+    # 3.0 drops widgets sepalwidgets subclasses (CalendarDaily); below 1.8 there is
+    # no _version.semver, which pysepal imports at startup. A cap alone lets a
+    # crowded solve fall through to 0.1.x.
+    "ipyvuetify>=1.8,<3",
     "markdown",
     "ipyleaflet>=0.14.0",  # to have access to data member in edition
     # earthengine management


### PR DESCRIPTION
The cap added for ipyvuetify 3.0 has no lower bound, so a crowded solve can fall all the way through to 0.1.x. That happened in sepal-contrib/sepal-leafmap CI, where leafmap's dependency tree pushed conda down to ipyvuetify 0.1.11 — released in 2019, and predating the `_version.semver` that `pysepal.frontend.styles` imports at startup. The environment resolved cleanly and the app then died with an ImportError.

1.8.10 is the oldest release that carries the symbol. Same change is on the 2.22.x and 3.8.x branches.