### PR TITLE
fix(mapping): keep the basemap order given by the caller

### DIFF
--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -197,7 +197,9 @@ class SepalMap(ipl.Map):
         theme_source = self._resolve_theme_source(theme_state, theme_toggle)
         default_basemap = "SEPAL_DARK" if self._theme_is_dark(theme_source) else "SEPAL_LIGHT"
         basemaps = basemaps or [default_basemap]
-        [self.add_basemap(basemap) for basemap in set(basemaps)]
+        # dict.fromkeys, not set: a set has no order, so the basemap left visible
+        # below would otherwise vary with the hash seed, i.e. at every restart.
+        [self.add_basemap(basemap) for basemap in dict.fromkeys(basemaps)]
 
         self._apply_theme_class(default_basemap == "SEPAL_DARK")
 

--- a/tests/test_mapping/test_SepalMap.py
+++ b/tests/test_mapping/test_SepalMap.py
@@ -50,6 +50,15 @@ def test_init() -> None:
     layers_name = [layer.name for layer in m.layers]
     assert all(b in layers_name for b in basemaps)
 
+    # the caller's order has to survive, as only the first one is left visible
+    assert layers_name[: len(basemaps)] == basemaps
+    assert m.layers[0].visible
+    assert not m.layers[1].visible
+
+    # duplicates are dropped without disturbing that order
+    m = sm.SepalMap(["CartoDB.Positron", "CartoDB.DarkMatter", "CartoDB.Positron"])
+    assert [layer.name for layer in m.layers][:2] == ["CartoDB.Positron", "CartoDB.DarkMatter"]
+
     # check that the map start with a DC
     m = sm.SepalMap(dc=True)
     assert m._id != id1


### PR DESCRIPTION
Same fix as #1040, forward-ported to v4 — the change is byte-identical, only the line offsets differ.

The basemaps were added from a `set`, so the one left visible varied with the hash seed at every restart. `dict.fromkeys` keeps the caller order and still drops duplicates.

Refs #1039