### PR TITLE
feat(gee): let asset exports set a pyramiding policy

### DIFF
--- a/docs/guides/migration-v4.md
+++ b/docs/guides/migration-v4.md
@@ -76,6 +76,15 @@ deleted branch: `pyramid_policy` on `export_image_to_asset`, and `dimensions`,
 `skip_empty_tiles` and `format_options` on `export_image_to_drive`. None had a
 caller in pysepal or in any downstream module.
 
+`pyramid_policy` has a successor. It was never a working parameter under either
+name: the session branch accepted it and dropped it, and the deleted branch sent
+it as `pyramidPolicy`, which Earth Engine rejects outright with
+`EEException: Unknown configuration options`. `export_image_to_asset` now takes
+`pyramiding_policy` and `pyramiding_policy_overrides`, spelled the way the REST
+API spells them and forwarded through ee-client. Reach for them on any
+categorical image: the server default is `MEAN`, which averages class codes in
+every overview level and renders the asset wrong below native zoom.
+
 **A task is now an ee-client model, not an `ee.batch.Task`.** `get_task` and
 `get_task_async` return `Optional[eeclient.tasks.Task]` — a pydantic model — and
 give you `None` for an unknown id. The deleted branch returned an `ee.batch.Task`
@@ -572,9 +581,10 @@ Rename the key. For the same reason `MapApp` takes `locales=` rather than a
       `GEEInterface()` now raises there.
 - [ ] Pass `gee_interface` to `get_viz_params` / `get_viz_params_async`; it is
       no longer optional.
-- [ ] Drop `pyramid_policy`, `dimensions`, `skip_empty_tiles` and
-      `format_options` from any `export_image_to_asset` / `export_image_to_drive`
-      call.
+- [ ] Drop `dimensions`, `skip_empty_tiles` and `format_options` from any
+      `export_image_to_drive` call, and rename `pyramid_policy` to
+      `pyramiding_policy` on `export_image_to_asset` — it never reached Earth
+      Engine under the old name.
 - [ ] Read a task's state as `task.metadata.state`, and handle `get_task`
       returning `None` instead of raising on an unknown id.
 - [ ] Replace every `pysepal.scripts.gee` call except `init_ee` and `need_ee`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "typing-extensions",
     "pydantic",  # SepalHeaders validation and the PYSEPAL_DEV_AUTH interlock
     "solara>=1.60,<2", # two private APIs are load-bearing: solara.scope.get_kernel_id and solara._using_solara_server
-    "ee-client>=3.1.0,<4", # provider-agnostic auth: EESession.from_*() factories (issue-12)
+    "ee-client>=3.2.0,<4", # AssetOptions carries the pyramiding policy (issue-1042)
     "pysepal-api>=0.3.0,<0.4", # UI-free SEPAL HTTP client (SepalClient: files/tasks/recipes); 0.x: a minor is a breaking release, so cap it
     "colorlog",
     "reactivex"

--- a/pysepal/scripts/gee_interface.py
+++ b/pysepal/scripts/gee_interface.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
 import ee
 from eeclient.client import EESession
 from eeclient.data import MapTileOptions
-from eeclient.export.image import ImageFileFormat
+from eeclient.export.image import ImageFileFormat, PyramidingPolicy
 from eeclient.export.table import TableFileFormat
 from eeclient.tasks import Task
 
@@ -420,6 +420,8 @@ class GEEInterface:
         scale: Optional[float] = None,
         crs: Optional[str] = None,
         crs_transform: Optional[dict] = None,
+        pyramiding_policy: Optional[PyramidingPolicy] = None,
+        pyramiding_policy_overrides: Optional[Dict[str, PyramidingPolicy]] = None,
     ) -> str:
         """Asynchronously export an image to an asset."""
         return await self.session.export.image_to_asset_async(
@@ -435,6 +437,8 @@ class GEEInterface:
             scale=scale,
             crs=crs,
             crs_transform=crs_transform,
+            pyramiding_policy=pyramiding_policy,
+            pyramiding_policy_overrides=pyramiding_policy_overrides,
         )
 
     async def export_image_to_drive_async(
@@ -592,6 +596,8 @@ class GEEInterface:
         crs_transform: Optional[List[float]] = None,
         max_pixels: Optional[int] = None,
         priority: Optional[int] = None,
+        pyramiding_policy: Optional[PyramidingPolicy] = None,
+        pyramiding_policy_overrides: Optional[Dict[str, PyramidingPolicy]] = None,
     ) -> str:
         """Export an image to an asset, blocking until done."""
         return self._run_async_blocking(
@@ -605,6 +611,8 @@ class GEEInterface:
                 crs_transform=crs_transform,
                 max_pixels=max_pixels,
                 priority=priority,
+                pyramiding_policy=pyramiding_policy,
+                pyramiding_policy_overrides=pyramiding_policy_overrides,
             )
         )
 

--- a/tests/test_scripts/test_gee_interface_session_paths.py
+++ b/tests/test_scripts/test_gee_interface_session_paths.py
@@ -51,6 +51,7 @@ def interface():
     session.operations.create_folder_async = AsyncMock(return_value={"id": "created"})
     session.export.table_to_drive_async = AsyncMock(return_value="table-task-id")
     session.export.image_to_drive_async = AsyncMock(return_value="image-task-id")
+    session.export.image_to_asset_async = AsyncMock(return_value="asset-task-id")
 
     interface = GEEInterface(session=session)
     try:
@@ -176,6 +177,60 @@ def test_export_image_to_drive_forwards_every_argument(interface):
         crs_transform=[1, 0, 0, 0, 1, 0],
         priority=7,
     )
+
+
+def test_export_image_to_asset_forwards_every_argument(interface):
+    image = MagicMock()
+    region = MagicMock()
+
+    result = interface.export_image_to_asset(
+        image=image,
+        asset_id="projects/p/assets/x",
+        description="my-image",
+        region=region,
+        scale=30,
+        crs="EPSG:4326",
+        crs_transform=[1, 0, 0, 0, 1, 0],
+        max_pixels=1e9,
+        priority=7,
+    )
+
+    assert result == "asset-task-id"
+    interface.session.export.image_to_asset_async.assert_awaited_once_with(
+        image=image,
+        asset_id="projects/p/assets/x",
+        description="my-image",
+        max_pixels=1e9,
+        grid=None,
+        request_id=None,
+        workload_tag=None,
+        priority=7,
+        region=region,
+        scale=30,
+        crs="EPSG:4326",
+        crs_transform=[1, 0, 0, 0, 1, 0],
+        pyramiding_policy=None,
+        pyramiding_policy_overrides=None,
+    )
+
+
+def test_export_image_to_asset_forwards_the_pyramiding_policy(interface):
+    """Issue #1042.
+
+    The server default is ``MEAN``, which averages class codes in every
+    overview of a categorical image. A caller asking for ``MODE`` has to reach
+    ee-client, not be dropped here.
+    """
+    interface.export_image_to_asset(
+        image=MagicMock(),
+        asset_id="projects/p/assets/x",
+        pyramiding_policy="mode",
+        pyramiding_policy_overrides={"B1": "min"},
+    )
+
+    kwargs = interface.session.export.image_to_asset_async.await_args.kwargs
+    assert kwargs["pyramiding_policy"] == "mode"
+    assert kwargs["pyramiding_policy_overrides"] == {"B1": "min"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1042.

Adds `pyramiding_policy` and `pyramiding_policy_overrides` to synchronous and asynchronous image asset exports, so categorical images can use `MODE` instead of Earth Engine’s default `MEAN`. Both options are forwarded through ee-client; omitting them preserves existing defaults.

Requires `ee-client>=3.2.0,<4`, now [available on PyPI](https://pypi.org/project/ee-client/3.2.0/). Includes forwarding regression tests and v4 migration notes.
