### PR TITLE
test(mapping): stop naming basemaps xyzservices can withdraw

### DIFF
--- a/tests/test_mapping/test_LayersControl.py
+++ b/tests/test_mapping/test_LayersControl.py
@@ -7,6 +7,7 @@ from ipyleaflet import Map, Marker, PMTilesLayer
 from pysepal import aoi
 from pysepal import mapping as sm
 from pysepal import sepalwidgets as sw
+from pysepal.mapping.basemaps import basemap_tiles
 
 
 @pytest.mark.gee
@@ -134,30 +135,31 @@ def test_select() -> None:
 @pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_change_basemap() -> None:
     """Check that besmap can be changed and that user can select 2 at a time."""
-    m = sm.SepalMap(["HYBRID", "CartoDB.Positron"])
+    terrain_name = basemap_tiles["TERRAIN"].name
+    m = sm.SepalMap(["HYBRID", "TERRAIN"])
     layer_control = next(c for c in m.controls if isinstance(c, sm.LayersControl))
     layer_rows = layer_control.tile.get_children(klass=sm.BaseRow)
-    carto_row = next(r for r in layer_rows if r.children[0].children[0] == "CartoDB.Positron")
+    terrain_row = next(r for r in layer_rows if r.children[0].children[0] == terrain_name)
     google_row = next(r for r in layer_rows if r.children[0].children[0] == "Google Satellite")
-    carto_layer = m.find_layer("CartoDB.Positron", base=True)
+    terrain_layer = m.find_layer(terrain_name, base=True)
     google_layer = m.find_layer("Google Satellite", base=True)
 
-    # select positron (their initial order is random)
-    carto_row.w_radio.active = True
+    # select terrain (their initial order is random)
+    terrain_row.w_radio.active = True
     assert google_row.w_radio.active is False
     assert google_layer.visible is False
-    assert carto_layer.visible is True
+    assert terrain_layer.visible is True
 
     # select google
     google_row.w_radio.active = True
-    assert carto_row.w_radio.active is False
+    assert terrain_row.w_radio.active is False
     assert google_layer.visible is True
-    assert carto_layer.visible is False
+    assert terrain_layer.visible is False
 
     # do it from the layers
-    carto_layer.visible = True
+    terrain_layer.visible = True
     assert google_row.w_radio.active is False
-    assert carto_row.w_radio.active is True
+    assert terrain_row.w_radio.active is True
     assert google_layer.visible is False
 
     return
@@ -167,7 +169,7 @@ def test_change_basemap() -> None:
 @pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_ungrouped() -> None:
     """Check that layer control can be displayed at the same time with other menus."""
-    m = sm.SepalMap(["HYBRID", "CartoDB.Positron"], vinspector=True)
+    m = sm.SepalMap(["HYBRID", "TERRAIN"], vinspector=True)
     layer_control = next(c for c in m.controls if isinstance(c, sm.LayersControl))
     m.v_inspector.menu.v_model = True
 

--- a/tests/test_mapping/test_SepalMap.py
+++ b/tests/test_mapping/test_SepalMap.py
@@ -13,6 +13,7 @@ from ipyleaflet import GeoJSON
 
 from pysepal import mapping as sm
 from pysepal.frontend import styles as ss
+from pysepal.mapping.basemaps import basemap_tiles, xyz_tiles
 from pysepal.mapping.legend_control import LegendControl
 from pysepal.mapping.visualization import get_viz_params
 from pysepal.scripts.gee_interface import GEEInterface
@@ -44,20 +45,23 @@ def test_init() -> None:
 
     # check that the map start with several basemaps
 
-    basemaps = ["CartoDB.DarkMatter", "CartoDB.Positron"]
+    # xyz_tiles keys, so that an upstream provider needing a key cannot take
+    # these out of basemap_tiles the way it took CartoDB out (#1044).
+    basemaps = ["ROADMAP", "TERRAIN"]
+    names = [basemap_tiles[b].name for b in basemaps]
     m = sm.SepalMap(basemaps)
     assert len(m.layers) == 3
     layers_name = [layer.name for layer in m.layers]
-    assert all(b in layers_name for b in basemaps)
+    assert all(n in layers_name for n in names)
 
     # the caller's order has to survive, as only the first one is left visible
-    assert layers_name[: len(basemaps)] == basemaps
+    assert layers_name[: len(names)] == names
     assert m.layers[0].visible
     assert not m.layers[1].visible
 
     # duplicates are dropped without disturbing that order
-    m = sm.SepalMap(["CartoDB.Positron", "CartoDB.DarkMatter", "CartoDB.Positron"])
-    assert [layer.name for layer in m.layers][:2] == ["CartoDB.Positron", "CartoDB.DarkMatter"]
+    m = sm.SepalMap([basemaps[1], basemaps[0], basemaps[1]])
+    assert [layer.name for layer in m.layers][:2] == [names[1], names[0]]
 
     # check that the map start with a DC
     m = sm.SepalMap(dc=True)
@@ -284,19 +288,17 @@ def test_add_ee_layer(image_id: str) -> None:
 
 
 def test_get_basemap_list() -> None:
-    """Set multiple basemaps on the SepalMap."""
-    # Retrieve 5 random maps
-    random_basemaps = [
-        "Esri.OceanBasemap",
-        "OpenStreetMap",
-        "HikeBike.HikeBike",
-        "HikeBike.HillShading",
-        "BasemapAT.orthofoto",
-    ]
+    """Every key SepalMap will accept as a basemap has to be listed.
 
+    Named providers used to stand in for "some upstream basemaps"; xyzservices
+    withdrew the whole CARTO family behind an API key in 2026.9.1 and the
+    stand-ins became a failing test (#1044). The list is asserted against its
+    two real sources instead.
+    """
     res = sm.SepalMap.get_basemap_list()
 
-    assert all([bm in res for bm in random_basemaps])
+    assert all(key in res for key in xyz_tiles)
+    assert set(sm.basemaps.get_xyz_dict()) <= set(res)
 
     return
 

--- a/tests/test_mapping/test_basemap_names.py
+++ b/tests/test_mapping/test_basemap_names.py
@@ -1,0 +1,53 @@
+"""No mapping test may hard-code a basemap that xyzservices can withdraw.
+
+Issue #1044. ``get_xyz_dict`` keeps a provider only while ``requires_token()``
+is false, so any provider xyzservices decides needs a key leaves
+``basemap_tiles`` on the next release and every test naming it starts raising
+``ValueError: Basemap can only be one of the following``. 2026.9.1 did exactly
+that to the whole CARTO family, breaking ``test_SepalMap::test_init`` on all
+three Python versions.
+
+pysepal #1035 saw this coming and took the library off those names, but left
+the tests that pass them as explicit basemaps. This guard is what stops the
+next one being written: only the entries pysepal defines itself in
+``xyz_tiles`` are ours to rely on.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from pysepal.mapping.basemaps import get_xyz_dict, xyz_tiles
+
+# This module names providers in its own failure message, so it cannot scan itself.
+MAPPING_TESTS = sorted(
+    p for p in Path(__file__).parent.glob("test_*.py") if p.name != Path(__file__).name
+)
+
+
+def _pysepal_owned() -> set:
+    """The basemap keys and layer names pysepal ships, which cannot disappear."""
+    return set(xyz_tiles) | {entry["name"] for entry in xyz_tiles.values()}
+
+
+def _string_constants(path: Path) -> set:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+@pytest.mark.parametrize("path", MAPPING_TESTS, ids=lambda p: p.name)
+def test_no_mapping_test_hard_codes_an_upstream_basemap(path: Path) -> None:
+    upstream = set(get_xyz_dict(free_only=False))
+    named = (_string_constants(path) & upstream) - _pysepal_owned()
+
+    assert not named, (
+        f"{path.name} names {sorted(named)}, which xyzservices owns. Any of these "
+        f"leaves basemap_tiles the moment upstream marks it as needing a key. "
+        f"Use an xyz_tiles key instead and resolve the layer name through "
+        f"basemap_tiles[key].name."
+    )

--- a/tests/test_mapping/test_basemaps.py
+++ b/tests/test_mapping/test_basemaps.py
@@ -3,36 +3,38 @@
 from ipyleaflet import TileLayer
 
 from pysepal import mapping as sm
+from pysepal.mapping.basemaps import xyz_tiles
 
 
 def test_get_xyz_dict() -> None:
-    """Check some known basemaps and assert they are in the list."""
-    # Retrieve 4 random maps
-    random_basemaps = [
-        "Esri.OceanBasemap",
-        "HikeBike.HikeBike",
-        "HikeBike.HillShading",
-        "BasemapAT.orthofoto",
-    ]
-    basemaps = sm.basemaps.get_xyz_dict()
-    assert all([m in basemaps for m in random_basemaps])
+    """Check the free set is the token-free subset of everything xyzservices ships.
+
+    Asserted as a property rather than against named providers: xyzservices
+    moves providers behind an API key between releases -- 2026.9.1 did it to
+    the whole CARTO family -- so any name hard-coded here is a future failure
+    (#1044).
+    """
+    free = sm.basemaps.get_xyz_dict()
+    every = sm.basemaps.get_xyz_dict(free_only=False)
+
+    assert free, "no keyless provider survived the filter"
+    assert set(free) <= set(every)
+    assert not any(p.requires_token() for p in free.values())
+    assert any(
+        p.requires_token() for p in every.values()
+    ), "free_only=False must also return the providers that need a key"
 
     return
 
 
 def test_xyz_to_leaflet() -> None:
     """Check the maps can be transformed in TileLayer."""
-    # Retrieve 1 random maps + the five manually added
-    random_basemaps = [
-        "Esri.OceanBasemap",
-        "OpenStreetMap",
-        "ROADMAP",
-        "SATELLITE",
-        "TERRAIN",
-        "HYBRID",
-    ]
     basemaps = sm.basemaps.xyz_to_leaflet()
-    assert all([m in basemaps for m in random_basemaps])
+
+    # only pysepal's own entries are guaranteed to be there; the xyzservices
+    # ones come and go with the upstream release.
+    assert all(key in basemaps for key in xyz_tiles)
+    assert set(sm.basemaps.get_xyz_dict()) <= set(basemaps)
 
     for tile in basemaps.values():
         assert isinstance(tile, TileLayer)


### PR DESCRIPTION
This PR closes #1044.

xyzservices 2026.9.1 changed all ten CARTO providers. Each one now needs an API key. `get_xyz_dict()` keeps only the providers that do not need a key. Therefore it removes the CARTO providers from `basemap_tiles`, and each test that uses a `CartoDB.*` name fails with `ValueError: Basemap can only be one of the following`.

Only CI shows this failure. CI installs the most recent xyzservices, because `ipyleaflet` installs it and there is no version limit.

PR #1035 removed these names from the library code, but it kept them in the tests. This PR removes the last of them. It does not add a version limit, because the list of free providers is external data and that data changes.

The issue shows only `CartoDB.DarkMatter`. But `CartoDB.Positron` also fails, therefore `test_change_basemap` and `test_ungrouped` are also wrong. CI does not run these two tests, because they have the `@pytest.mark.gee` mark. Four more names in `test_basemaps.py` and `test_get_basemap_list` have the same risk.

The tests now use only `xyz_tiles` keys. pysepal makes these keys, therefore xyzservices cannot remove them. The tests find the layer name with `basemap_tiles[key].name`, because the key and the name are different for most entries. The new file `test_basemap_names.py` reads the other test files and fails if one of them uses an xyzservices name.

To test this, I changed the CARTO data on my computer to the same data as 2026.9.1. The 149 mapping tests pass with the old data and with the new data. All 924 unit tests pass. The 5 errors come from a missing `pytest-regressions` package and they are not new. The two GEE tests need credentials, therefore I ran their basemap steps with `gee=False` instead.
