### PR TITLE
fix(solara): merge the server assets once per process

### DIFF
--- a/pysepal/solara/setup.py
+++ b/pysepal/solara/setup.py
@@ -4,14 +4,18 @@ This module provides utilities to configure common Solara server settings
 that are typically needed across all pysepal-based applications.
 """
 
+import atexit
 import logging
+import shutil
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 import solara
 import solara.server.settings
 
-from .asset_merger import create_merged_assets_directory
+from pysepal.scripts.scratch import scratch_dir
+
+from .asset_merger import merge_asset_files
 
 logger = logging.getLogger("sepalui.solara.setup")
 
@@ -55,6 +59,10 @@ def setup_theme_colors():
     solara.lab.theme.themes.light.menu = "#FFFFFF"
 
 
+_merged_root: Optional[Path] = None
+_merged_locations: Tuple[Path, ...] = ()
+
+
 def setup_solara_server(
     extra_asset_locations: Optional[List[Union[str, Path]]] = None,
 ) -> None:
@@ -69,35 +77,80 @@ def setup_solara_server(
     - pysepal common assets (CSS, JS)
     - No kernel timeout ("0s") (helps to kill sessions once the page is closed)
 
-    If extra asset locations are provided, this function will merge all CSS and JS
-    files into combined files to ensure they are all properly served by Solara.
+    Solara serves extra assets from one location, so the CSS and JS of pysepal
+    and of every extra location are merged into one folder. That folder is
+    created once per process and removed at exit. A repeated call is cheap: with
+    no new location and no changed source file it does nothing, and with new
+    locations it merges the union into the same folder. Several apps in one
+    server, or a reload of the app module, therefore share one folder.
 
     Args:
         extra_asset_locations: Additional asset locations to serve beyond pysepal's common assets
 
     """
-    logger.debug("Setting up Solara server configuration for sepal_ui application")
+    global _merged_root, _merged_locations
 
     solara.server.settings.assets.fontawesome_path = DEFAULT_FONT_AWESOME
     solara.server.settings.kernel.cull_timeout = DEFAULT_CULL_TIMEOUT
 
-    # Get pysepal common assets
     sepal_common_assets = Path(__file__).parent / "common" / "assets"
     if not sepal_common_assets.exists():
         logger.warning(f"sepal_ui common assets directory not found: {sepal_common_assets}")
         return
 
-    # Always merge so the shared base.css is served alongside the Solara
-    # override sheet (and any extra locations). Both the "no extra locations"
-    # and "extra locations" cases go through the same path.
-    extra_paths = [Path(loc) for loc in (extra_asset_locations or [])]
-    if extra_paths:
-        logger.debug(f"Extra asset locations: {[str(p) for p in extra_paths]}")
+    requested = [Path(location).resolve() for location in (extra_asset_locations or [])]
+    new = tuple(dict.fromkeys(p for p in requested if p not in _merged_locations))
+    if _merged_root is not None and not new and _merged_is_current(sepal_common_assets):
+        logger.debug(f"Solara assets already merged at: {_merged_root / 'assets'}")
+        return
 
-    merged_assets_dir = create_merged_assets_directory(
-        sepal_common_assets, extra_paths, base_css_files=[SHARED_BASE_CSS]
+    logger.debug("Setting up Solara server configuration for sepal_ui application")
+    if _merged_root is None:
+        _merged_root = scratch_dir(prefix="sepal_ui_assets_")
+        atexit.register(_remove_merged_assets)
+        logger.debug(f"Created temporary assets directory: {_merged_root}")
+    _merged_root.mkdir(parents=True, exist_ok=True)
+    _merged_locations += new
+    if _merged_locations:
+        logger.debug(f"Extra asset locations: {[str(p) for p in _merged_locations]}")
+
+    merge_asset_files(
+        sepal_common_assets,
+        list(_merged_locations),
+        _merged_root,
+        base_css_files=[SHARED_BASE_CSS],
     )
+    merged_assets_dir = _merged_root / "assets"
     solara.server.settings.assets.extra_locations = [str(merged_assets_dir)]
     logger.debug(f"Asset location set to merged directory: {merged_assets_dir}")
 
     logger.info("Solara server configuration completed successfully")
+
+
+def _merged_is_current(sepal_common_assets: Path) -> bool:
+    """Whether the merged files are at least as new as every source file."""
+    merged_css = _merged_root / "assets" / "custom.css"
+    if not merged_css.exists():
+        return False
+    merged_at = merged_css.stat().st_mtime_ns
+    return all(
+        source.stat().st_mtime_ns <= merged_at for source in _source_files(sepal_common_assets)
+    )
+
+
+def _source_files(sepal_common_assets: Path) -> Iterator[Path]:
+    if SHARED_BASE_CSS.is_file():
+        yield SHARED_BASE_CSS
+    yield from (path for path in sepal_common_assets.iterdir() if path.is_file())
+    for location in _merged_locations:
+        for pattern in ("**/*.css", "**/*.js"):
+            yield from (path for path in location.glob(pattern) if path.is_file())
+
+
+def _remove_merged_assets() -> None:
+    """Delete the merged assets folder and forget it. Registered with ``atexit``."""
+    global _merged_root, _merged_locations
+    if _merged_root is not None:
+        shutil.rmtree(_merged_root, ignore_errors=True)
+    _merged_root = None
+    _merged_locations = ()

--- a/tests/test_solara/test_setup.py
+++ b/tests/test_solara/test_setup.py
@@ -1,0 +1,97 @@
+"""``setup_solara_server`` merges the assets once per process."""
+
+import atexit
+import os
+from pathlib import Path
+
+import pytest
+import solara.server.settings
+
+import pysepal.scripts.scratch as scratch
+import pysepal.solara.setup as setup
+
+
+@pytest.fixture
+def scratch_root(monkeypatch, tmp_path):
+    """Start with no merged folder and create scratch folders under ``tmp_path``."""
+    setup._remove_merged_assets()
+    monkeypatch.setattr(scratch, "scratch_root", lambda: tmp_path)
+    monkeypatch.setattr(atexit, "register", lambda fn: fn)
+    monkeypatch.setattr(solara.server.settings.assets, "extra_locations", [])
+    yield tmp_path
+    setup._remove_merged_assets()
+
+
+def merged_folders(root: Path) -> list:
+    return sorted(root.glob("sepal_ui_assets_*"))
+
+
+def merged_css() -> Path:
+    (location,) = solara.server.settings.assets.extra_locations
+    return Path(location) / "custom.css"
+
+
+def write_extra(root: Path, rule: str) -> Path:
+    extra = root / "extra"
+    extra.mkdir(exist_ok=True)
+    (extra / "app.css").write_text(rule)
+    return extra
+
+
+def test_a_second_call_reuses_the_merged_folder(scratch_root):
+    setup.setup_solara_server(extra_asset_locations=[])
+    first = list(solara.server.settings.assets.extra_locations)
+
+    setup.setup_solara_server(extra_asset_locations=[])
+    setup.setup_solara_server()
+
+    assert solara.server.settings.assets.extra_locations == first
+    assert len(merged_folders(scratch_root)) == 1
+
+
+def test_a_later_call_adds_new_locations_to_the_same_folder(scratch_root):
+    extra = write_extra(scratch_root, ".app-marker { color: red; }")
+    setup.setup_solara_server(extra_asset_locations=[])
+    assert ".app-marker" not in merged_css().read_text()
+
+    setup.setup_solara_server(extra_asset_locations=[extra])
+
+    assert ".app-marker" in merged_css().read_text()
+    assert len(merged_folders(scratch_root)) == 1
+
+
+def test_unchanged_inputs_do_not_merge_again(scratch_root, monkeypatch):
+    extra = write_extra(scratch_root, ".app-marker {}")
+    setup.setup_solara_server(extra_asset_locations=[extra])
+    merges = []
+    monkeypatch.setattr(setup, "merge_asset_files", lambda *args, **kwargs: merges.append(args))
+
+    setup.setup_solara_server(extra_asset_locations=[extra])
+    setup.setup_solara_server(extra_asset_locations=[str(extra)])
+
+    assert merges == []
+
+
+def test_a_changed_source_file_is_merged_again(scratch_root):
+    extra = write_extra(scratch_root, ".app-marker { color: red; }")
+    setup.setup_solara_server(extra_asset_locations=[extra])
+    later = merged_css().stat().st_mtime_ns + 10**9
+    (extra / "app.css").write_text(".app-marker { color: blue; }")
+    os.utime(extra / "app.css", ns=(later, later))
+
+    setup.setup_solara_server(extra_asset_locations=[extra])
+
+    assert "blue" in merged_css().read_text()
+    assert len(merged_folders(scratch_root)) == 1
+
+
+def test_the_merged_folder_is_removed_at_exit(scratch_root, monkeypatch):
+    registered = []
+    monkeypatch.setattr(atexit, "register", lambda fn: registered.append(fn) or fn)
+
+    setup.setup_solara_server()
+    (folder,) = merged_folders(scratch_root)
+    (cleanup,) = registered
+    cleanup()
+
+    assert not folder.exists()


### PR DESCRIPTION
`setup_solara_server()` created a new merged assets folder on every call. The demo gallery calls it once per demo app, so one launch logged four setup blocks and left three orphaned folders in the temp directory. A reload of an app module did the same.

The setup now keeps one folder for the life of the process. A repeated call with no new location and no changed source file does nothing. A call with new locations merges the union into the same folder. A changed source file, for example an app stylesheet edited during development, is merged again. The folder is removed at exit.

Tested with five new unit tests and by importing `demo_apps/gallery.py`: one merge, three "already merged" lines, and the same asset location for all routes.
